### PR TITLE
Support nucleic acids

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -37,5 +37,7 @@ dependencies:
   # Data
   - numpy
 
-  #- pip:
-  #  - codecov
+  - pip:
+      # - codecov
+      - git+https://github.com/openforcefield/openff-toolkit.git@better_typing
+      - git+https://github.com/openforcefield/openff-units.git@better_typing

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -493,7 +493,7 @@ def _add_to_molecule(
                 for old_idx, atom in enumerate(this_molecule.atoms):
                     old_to_new[old_idx] = other_molecule._add_atom(
                         atomic_number=atom.atomic_number,
-                        formal_charge=atom.formal_charge.m,
+                        formal_charge=atom.formal_charge.m,  # type:ignore
                         is_aromatic=atom.is_aromatic,
                         stereochemistry=atom.stereochemistry,
                         name=atom.name,

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -407,10 +407,6 @@ def _add_to_molecule(
     for pdb_index in sorted(residue_match.res_atom_idcs):
         atom_def = residue_match.atom(pdb_index)
 
-        if data.alt_loc[pdb_index] != "":
-            # TODO: Support altlocs (probably in PdbData, maybe PdbData.residues()?)
-            raise ValueError("altloc not yet supported")
-
         mol_atom_idx = this_molecule._add_atom(
             atomic_number=elements.NUMBERS[atom_def.symbol],
             formal_charge=atom_def.charge,

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -10,7 +10,6 @@ from typing import Any, DefaultDict, Self
 
 from ._utils import __UNSET__, dec_hex, int_or_none, with_neighbours
 from .exceptions import (
-    NoMatchingResidueDefinitionError,
     UnknownOrAmbiguousSerialInConectError,
 )
 from .residue import AtomDefinition, ResidueDefinition
@@ -485,16 +484,6 @@ class PdbData:
                     )
                     if match is not None:
                         residue_matches.append(match)
-
-            if len(residue_matches) == 0:
-                raise NoMatchingResidueDefinitionError(
-                    res_atom_idcs,
-                    self,
-                    unknown_molecules=[],
-                    additional_substructures=additional_substructures,
-                    residue_database=residue_database,
-                    verbose_errors=True,
-                )
 
             name_matches.append(residue_matches)
 

--- a/openff/pablo/_tests/test_ccd.py
+++ b/openff/pablo/_tests/test_ccd.py
@@ -1,0 +1,42 @@
+import pytest
+
+from openff.pablo.ccd import CCD_RESIDUE_DEFINITION_CACHE
+
+
+@pytest.mark.parametrize(
+    "resname",
+    [
+        "ALA",
+        "ARG",
+        "ASN",
+        "ASP",
+        "CYS",
+        "GLN",
+        "GLU",
+        "GLY",
+        "HIS",
+        "ILE",
+        "LEU",
+        "LYS",
+        "MET",
+        "PHE",
+        "PRO",
+        "SER",
+        "THR",
+        "TRP",
+        "TYR",
+        "VAL",
+        "DG",
+        "DA",
+        "DT",
+        "DC",
+        "G",
+        "A",
+        "U",
+        "C",
+        "ACE",
+        "NME",
+    ],
+)
+def test_ccdcache_can_load_common_residues(resname: str):
+    CCD_RESIDUE_DEFINITION_CACHE[resname]

--- a/openff/pablo/_tests/test_patches.py
+++ b/openff/pablo/_tests/test_patches.py
@@ -1,0 +1,51 @@
+from openff.pablo.ccd.patches import disambiguate_alt_ids
+from openff.pablo.residue import (
+    AtomDefinition,
+    BondDefinition,
+    ResidueDefinition,
+    _skip_residue_definition_validation,
+)
+
+
+def test_disambiguate_alt_ids():
+    with _skip_residue_definition_validation():
+        with_synonyms = ResidueDefinition(
+            atoms=(
+                AtomDefinition.with_defaults(name="H1", symbol="H", synonyms=["H2"]),
+                AtomDefinition.with_defaults(name="H2", symbol="H", synonyms=["H3"]),
+                AtomDefinition.with_defaults(name="O", symbol="O", synonyms=["O1"]),
+            ),
+            bonds=(
+                BondDefinition.with_defaults("O", "H1"),
+                BondDefinition.with_defaults("O", "H2"),
+            ),
+            crosslink=BondDefinition.with_defaults("O", "H1", order=0),
+            description="water with clashing synonyms",
+            linking_bond=BondDefinition.with_defaults("O", "H2", order=0),
+            residue_name="HOH",
+        )
+        res1, res2 = disambiguate_alt_ids(with_synonyms)
+
+    assert res1 == with_synonyms.replace(
+        atoms=(
+            AtomDefinition.with_defaults(name="H1", symbol="H"),
+            AtomDefinition.with_defaults(name="H2", symbol="H"),
+            AtomDefinition.with_defaults(name="O", symbol="O"),
+        ),
+    )
+
+    assert res2.description == with_synonyms.description + " altids"
+    assert set(res2.atoms) == {
+        AtomDefinition.with_defaults(name="H2", symbol="H"),
+        AtomDefinition.with_defaults(name="H3", symbol="H"),
+        AtomDefinition.with_defaults(name="O1", symbol="O"),
+    }
+    assert set(res2.bonds) == {
+        BondDefinition.with_defaults("O1", "H2"),
+        BondDefinition.with_defaults("O1", "H3"),
+    }
+    assert res2.linking_bond == BondDefinition.with_defaults("O1", "H3", order=0)
+    assert res2.crosslink == BondDefinition.with_defaults("O1", "H2", order=0)
+
+    res1._validate()
+    res2._validate()

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -278,6 +278,7 @@ class TestPdbData:
             chain_id=["A"] * 6 + ["B"] * 6,
             res_seq=[1] * 8 + [2] * 4,
             i_code=[" "] * 10 + ["A"] * 2,
+            alt_loc=[""] * 12,
         )
 
         assert list(data.residue_indices) == [

--- a/openff/pablo/_tests/test_pdb_files.py
+++ b/openff/pablo/_tests/test_pdb_files.py
@@ -120,6 +120,6 @@ def connectivity_and_atom_order_and_net_residue_charge_and_metadata_matches_lega
     for pablo_res, legacy_res in zip(pablo_top.residues, legacy_top.residues):
         pablo_res_charge, legacy_res_charge = 0, 0
         for pablo_atom, legacy_atom in zip(pablo_res.atoms, legacy_res.atoms):
-            pablo_res_charge += pablo_atom.formal_charge
-            legacy_res_charge += legacy_atom.formal_charge
+            pablo_res_charge += pablo_atom.formal_charge  # type:ignore
+            legacy_res_charge += legacy_atom.formal_charge  # type:ignore
         assert pablo_res_charge == legacy_res_charge

--- a/openff/pablo/_tests/test_utils.py
+++ b/openff/pablo/_tests/test_utils.py
@@ -104,13 +104,13 @@ def test_assign_stereochemistry_from_3d_bonds():
     cis_mol.generate_conformers(n_conformers=1)
     trans_mol.generate_conformers(n_conformers=1)
 
-    undef_mol.add_conformer(cis_mol.conformers[0])  # type:ignore[index]
+    undef_mol.add_conformer(cis_mol.conformers[0])  # type:ignore
     assign_stereochemistry_from_3d(undef_mol)
     assert "Z" in [bond.stereochemistry for bond in undef_mol.bonds]
 
     undef_mol.generate_conformers(n_conformers=0)
 
-    undef_mol.add_conformer(trans_mol.conformers[0])  # type:ignore[index]
+    undef_mol.add_conformer(trans_mol.conformers[0])  # type:ignore
     assign_stereochemistry_from_3d(undef_mol)
     assert "E" in [bond.stereochemistry for bond in undef_mol.bonds]
 
@@ -127,12 +127,15 @@ def test_assign_stereochemistry_from_3d_atoms():
     r_mol.generate_conformers(n_conformers=1)
     s_mol.generate_conformers(n_conformers=1)
 
-    undef_mol.add_conformer(r_mol.conformers[0])  # type:ignore[index]
+    assert r_mol.conformers is not None
+    assert s_mol.conformers is not None
+
+    undef_mol.add_conformer(r_mol.conformers[0])
     assign_stereochemistry_from_3d(undef_mol)
     assert undef_mol.atom(0).stereochemistry == "R"
 
     undef_mol.generate_conformers(n_conformers=0)
 
-    undef_mol.add_conformer(s_mol.conformers[0])  # type:ignore[index]
+    undef_mol.add_conformer(s_mol.conformers[0])
     assign_stereochemistry_from_3d(undef_mol)
     assert undef_mol.atom(0).stereochemistry == "S"

--- a/openff/pablo/_utils.py
+++ b/openff/pablo/_utils.py
@@ -26,6 +26,7 @@ __all__ = [
     "cryst_to_box_vectors",
     "assign_stereochemistry_from_3d",
     "__UNSET__",
+    "dbg",
 ]
 
 T = TypeVar("T")
@@ -38,6 +39,13 @@ CIFValue: TypeAlias = str | float | int
 
 class __UNSET__:
     pass
+
+
+def dbg(o: T, msg: str = "{}") -> T:
+    if "{}" not in msg:
+        msg += ": {}"
+    print(msg.format(o))
+    return o
 
 
 def default_dict(

--- a/openff/pablo/ccd/__init__.py
+++ b/openff/pablo/ccd/__init__.py
@@ -11,11 +11,13 @@ from pathlib import Path
 from . import patches
 from ._ccdcache import CcdCache
 from .patches import (
+    add_dephosphorylated_5p_terminus,
     add_disulfide_crosslink,
     add_protonation_variants,
     add_synonyms,
     disambiguate_alt_ids,
     fix_caps,
+    set_hop3_leaving,
 )
 
 __all__ = [
@@ -35,6 +37,26 @@ CCD_RESIDUE_DEFINITION_CACHE: CcdCache = CcdCache(
             "CYS": add_disulfide_crosslink,
         },
         {"*": add_protonation_variants},
+        {
+            "U": add_dephosphorylated_5p_terminus,
+            "G": add_dephosphorylated_5p_terminus,
+            "C": add_dephosphorylated_5p_terminus,
+            "A": add_dephosphorylated_5p_terminus,
+            "DT": add_dephosphorylated_5p_terminus,
+            "DG": add_dephosphorylated_5p_terminus,
+            "DC": add_dephosphorylated_5p_terminus,
+            "DA": add_dephosphorylated_5p_terminus,
+        },
+        {
+            "U": set_hop3_leaving,
+            "G": set_hop3_leaving,
+            "C": set_hop3_leaving,
+            "A": set_hop3_leaving,
+            "DT": set_hop3_leaving,
+            "DG": set_hop3_leaving,
+            "DC": set_hop3_leaving,
+            "DA": set_hop3_leaving,
+        },
         {"*": disambiguate_alt_ids},
         {"*": add_synonyms},
     ],

--- a/openff/pablo/ccd/_ccdcache.py
+++ b/openff/pablo/ccd/_ccdcache.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 
 from openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
 
-from ..chem import PEPTIDE_BOND
+from ..chem import PEPTIDE_BOND, PHOSPHODIESTER_BOND
 from ..residue import (
     AtomDefinition,
     BondDefinition,
@@ -263,9 +263,9 @@ LINKING_TYPES: dict[str, BondDefinition | None] = {
     # "D-saccharide, beta linking".upper(): [],
     # "DNA OH 3 prime terminus".upper(): [],
     # "DNA OH 5 prime terminus".upper(): [],
-    # "DNA linking".upper(): [],
-    # "L-DNA linking".upper(): [],
-    # "L-RNA linking".upper(): [],
+    "DNA linking".upper(): PHOSPHODIESTER_BOND,
+    "L-DNA linking".upper(): PHOSPHODIESTER_BOND,
+    "L-RNA linking".upper(): PHOSPHODIESTER_BOND,
     # "L-beta-peptide, C-gamma linking".upper(): [],
     # "L-gamma-peptide, C-delta linking".upper(): [],
     # "L-peptide COOH carboxy terminus".upper(): [],
@@ -276,7 +276,7 @@ LINKING_TYPES: dict[str, BondDefinition | None] = {
     # "L-saccharide, beta linking".upper(): [],
     # "RNA OH 3 prime terminus".upper(): [],
     # "RNA OH 5 prime terminus".upper(): [],
-    # "RNA linking".upper(): [],
+    "RNA linking".upper(): PHOSPHODIESTER_BOND,
     "non-polymer".upper(): None,
     # "other".upper(): [],
     "peptide linking".upper(): PEPTIDE_BOND,

--- a/openff/pablo/chem.py
+++ b/openff/pablo/chem.py
@@ -7,6 +7,7 @@ from openff.pablo.residue import BondDefinition
 __all__ = [
     "DISULFIDE_BOND",
     "PEPTIDE_BOND",
+    "PHOSPHODIESTER_BOND",
 ]
 
 DISULFIDE_BOND = BondDefinition(
@@ -20,6 +21,14 @@ DISULFIDE_BOND = BondDefinition(
 PEPTIDE_BOND = BondDefinition(
     atom1="C",
     atom2="N",
+    order=1,
+    aromatic=False,
+    stereo=None,
+)
+
+PHOSPHODIESTER_BOND = BondDefinition(
+    atom1="O3'",
+    atom2="P",
     order=1,
     aromatic=False,
     stereo=None,

--- a/openff/pablo/residue.py
+++ b/openff/pablo/residue.py
@@ -13,7 +13,7 @@ from typing import Literal, Self
 from openff.toolkit import Molecule
 from openff.units import elements, unit
 
-from openff.pablo._utils import unwrap
+from openff.pablo._utils import __UNSET__, unwrap
 
 __all__ = [
     "AtomDefinition",
@@ -25,7 +25,7 @@ _residue_definition_skip_validation = False
 
 
 @contextmanager
-def _defer_residue_definition_validation():  # type: ignore[deadcode]
+def _skip_residue_definition_validation():  # type: ignore[deadcode]
     global _residue_definition_skip_validation
     _residue_definition_skip_validation = True
     yield
@@ -82,6 +82,28 @@ class AtomDefinition:
             stereo=stereo,
         )
 
+    def replace(
+        self,
+        name: str | __UNSET__ = __UNSET__(),
+        symbol: str | __UNSET__ = __UNSET__(),
+        synonyms: Iterable[str] | __UNSET__ = __UNSET__(),
+        leaving: bool | __UNSET__ = __UNSET__(),
+        charge: int | __UNSET__ = __UNSET__(),
+        aromatic: bool | __UNSET__ = __UNSET__(),
+        stereo: Literal["S", "R"] | None | __UNSET__ = __UNSET__(),
+    ) -> Self:
+        return self.__class__(
+            name=self.name if isinstance(name, __UNSET__) else name,
+            symbol=self.symbol if isinstance(symbol, __UNSET__) else symbol,
+            synonyms=(
+                self.synonyms if isinstance(synonyms, __UNSET__) else tuple(synonyms)
+            ),
+            leaving=self.leaving if isinstance(leaving, __UNSET__) else leaving,
+            charge=self.charge if isinstance(charge, __UNSET__) else charge,
+            aromatic=self.aromatic if isinstance(aromatic, __UNSET__) else aromatic,
+            stereo=self.stereo if isinstance(stereo, __UNSET__) else stereo,
+        )
+
 
 @dataclass(frozen=True)
 class BondDefinition:
@@ -119,6 +141,22 @@ class BondDefinition:
             order=order,
             aromatic=aromatic,
             stereo=stereo,
+        )
+
+    def replace(
+        self,
+        atom1: str | __UNSET__ = __UNSET__(),
+        atom2: str | __UNSET__ = __UNSET__(),
+        order: int | __UNSET__ = __UNSET__(),
+        aromatic: bool | __UNSET__ = __UNSET__(),
+        stereo: Literal["E", "Z"] | None | __UNSET__ = __UNSET__(),
+    ) -> Self:
+        return self.__class__(
+            atom1=self.atom1 if isinstance(atom1, __UNSET__) else atom1,
+            atom2=self.atom2 if isinstance(atom2, __UNSET__) else atom2,
+            order=self.order if isinstance(order, __UNSET__) else order,
+            aromatic=(self.aromatic if isinstance(aromatic, __UNSET__) else aromatic),
+            stereo=self.stereo if isinstance(stereo, __UNSET__) else stereo,
         )
 
 
@@ -199,6 +237,34 @@ class ResidueDefinition:
     bonds: tuple[BondDefinition, ...]
     """The bond definitions that make up this residue"""
 
+    def replace(
+        self,
+        residue_name: str | __UNSET__ = __UNSET__(),
+        description: str | __UNSET__ = __UNSET__(),
+        linking_bond: BondDefinition | None | __UNSET__ = __UNSET__(),
+        crosslink: BondDefinition | None | __UNSET__ = __UNSET__(),
+        atoms: Iterable[AtomDefinition] | __UNSET__ = __UNSET__(),
+        bonds: Iterable[BondDefinition] | __UNSET__ = __UNSET__(),
+    ) -> Self:
+        return self.__class__(
+            residue_name=(
+                self.residue_name
+                if isinstance(residue_name, __UNSET__)
+                else residue_name
+            ),
+            description=(
+                self.description if isinstance(description, __UNSET__) else description
+            ),
+            linking_bond=(
+                self.linking_bond
+                if isinstance(linking_bond, __UNSET__)
+                else linking_bond
+            ),
+            crosslink=self.crosslink if isinstance(crosslink, __UNSET__) else crosslink,
+            atoms=self.atoms if isinstance(atoms, __UNSET__) else tuple(atoms),
+            bonds=self.bonds if isinstance(bonds, __UNSET__) else tuple(bonds),
+        )
+
     def __post_init__(self):
         if _residue_definition_skip_validation:
             return
@@ -206,31 +272,37 @@ class ResidueDefinition:
         self._validate()
 
     def _validate(self):
-        if (
-            self.linking_bond is None
-            and self.crosslink is None
-            and True in {atom.leaving for atom in self.atoms}
-        ):
-            raise ValueError(
-                f"{self.residue_name}: Leaving atoms were specified, but there is no linking bond or crosslink",
-                self,
-            )
-        if len({atom.name for atom in self.atoms}) != len(self.atoms):
-            raise ValueError(
-                f"{self.residue_name}: All atoms must have unique canonical names",
-            )
+        try:
+            if (
+                self.linking_bond is None
+                and self.crosslink is None
+                and True in {atom.leaving for atom in self.atoms}
+            ):
+                raise ValueError(
+                    f"{self.residue_name}: Leaving atoms were specified, but there is no linking bond or crosslink",
+                    self,
+                )
+            if len({atom.name for atom in self.atoms}) != len(self.atoms):
+                raise ValueError(
+                    f"{self.residue_name}: All atoms must have unique canonical names",
+                )
 
-        all_leaving_atoms = {atom.name for atom in self.atoms if atom.leaving}
-        assigned_leaving_atoms = (
-            self.prior_bond_leaving_atoms
-            | self.posterior_bond_leaving_atoms
-            | self.crosslink_leaving_atoms
-        )
-        unassigned_leaving_atoms = all_leaving_atoms.difference(assigned_leaving_atoms)
-        if len(unassigned_leaving_atoms) != 0:
-            raise ValueError(
-                f"{self.residue_name}: Leaving atoms could not be assigned to a bond: {unassigned_leaving_atoms}",
+            all_leaving_atoms = {atom.name for atom in self.atoms if atom.leaving}
+            assigned_leaving_atoms = (
+                self.prior_bond_leaving_atoms
+                | self.posterior_bond_leaving_atoms
+                | self.crosslink_leaving_atoms
             )
+            unassigned_leaving_atoms = all_leaving_atoms.difference(
+                assigned_leaving_atoms,
+            )
+            if len(unassigned_leaving_atoms) != 0:
+                raise ValueError(
+                    f"{self.residue_name}: Leaving atoms could not be assigned to a bond: {unassigned_leaving_atoms}",
+                )
+        except KeyError as e:
+            # print(self)
+            raise e
 
     @classmethod
     def from_molecule(
@@ -512,19 +584,27 @@ class ResidueDefinition:
                 yield bond.atom1
 
     def _leaving_fragment_of(self, linking_atom: str) -> Iterator[str]:
+        # print(f"{self=} {linking_atom=}")
         atoms_to_check = list(self.atoms_bonded_to(linking_atom))
         checked_atoms: set[str] = set()
         while atoms_to_check:
             atom_name = atoms_to_check.pop()
+            # print(f"{atoms_to_check=} {checked_atoms=} {atom_name=}")
             if self.name_to_atom[atom_name].leaving:
+                # print(1)
                 yield atom_name
+                # print(2)
                 atoms_to_check.extend(
                     filter(
                         lambda x: x not in checked_atoms,
                         self.atoms_bonded_to(atom_name),
                     ),
                 )
+                # print(3)
             checked_atoms.add(atom_name)
+            # print(4)
+
+        # print(5)
 
     @cached_property
     def posterior_bond_leaving_atoms(self) -> set[str]:


### PR DESCRIPTION
Adds support for nucleic acids by defining the phosphodiester linking bond.

Todo:
- [x] Support phosphodiester linking bonds
- [ ] Support common nucleic acid terminii
    - [x] 5' dephosphorylated
    - [ ] 3' phosphorylated
    - [x] Charged 3'
    - [x] Uncharged 3'
    - [x] Charged 5'
    - [x] Uncharged 5'
    - [ ] ACE/ME cap
- [x] Fixes #12 