### PR TITLE
Fix crosslink reordering

### DIFF
--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -182,6 +182,17 @@ def topology_from_pdb(
     distributed with this software, so by default internet access is required to
     use it.
 
+    The produced ``Topology`` will have its atoms in the same order as the PDB
+    file in all cases except when the atoms in one molecule are divided by
+    another molecule. This can happen, for example, if a PDB file with 3 chains
+    A, B and C has a disulfide bond between A and C. In this case, chains A and
+    C form a single molecule, but the atoms from B should be in the middle. This
+    atom ordering cannot be represented in :py:class:`openff.toolkit.Topology`
+    unless all 3 chains are included in a single
+    :py:class:`openff.toolkit.Molecule`, which would then represent two distinct
+    molecules. When this occurs, atoms from the latter chain(s) appear
+    immediately after the first, and atoms from other molecules appear after.
+
     The following metadata are specified for all atoms produced by this function
     and can be accessed via ``topology.atom(i).metadata[key]``:
 

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -51,6 +51,7 @@ def _match_unknown_molecules(
                 "atom_serial": data.serial[pdb_index],
                 "b_factor": str(data.temp_factor[pdb_index]),
                 "occupancy": str(data.occupancy[pdb_index]),
+                "alt_loc": str(data.alt_loc[pdb_index]),
             },
         )
         for conect_idx in data.conects[pdb_index]:
@@ -217,6 +218,8 @@ def topology_from_pdb(
         The temperature b-factor for the atom.
     ``"occupancy"``
         The occupancy for the atom.
+    ``"alt_loc"``
+        The alternate location code for the atom.
 
     """
     # TODO: support streams and gzipped files
@@ -430,6 +433,7 @@ def _add_to_molecule(
                 "matched_residue_description": residue_match.residue_definition.description,
                 "b_factor": str(data.temp_factor[pdb_index]),
                 "occupancy": str(data.occupancy[pdb_index]),
+                "alt_loc": str(data.alt_loc[pdb_index]),
             },
             invalidate_cache=False,
         )

--- a/openff/pablo/_tests/test_pdb.py
+++ b/openff/pablo/_tests/test_pdb.py
@@ -58,6 +58,7 @@ class TestMatchUnknownMolecules:
             assert atom.metadata["chain_id"] == e2_data.chain_id[i]
             assert atom.metadata["pdb_index"] == i
             assert atom.metadata["atom_serial"] == e2_data.serial[i]
+            assert atom.metadata["alt_loc"] == e2_data.alt_loc[i]
             assert float(atom.metadata["b_factor"]) == e2_data.temp_factor[i]
             assert float(atom.metadata["occupancy"]) == e2_data.occupancy[i]
             assert "used_synonym" not in atom.metadata


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Cherry picked from #15 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Fixes positions being out of order when topology atom order cannot match PDB
 - Documents and warns on the above edge case
 - Stores altLoc in atom metadata
