### PR TITLE
Protonation variant api

### DIFF
--- a/openff/pablo/_tests/conftest.py
+++ b/openff/pablo/_tests/conftest.py
@@ -213,6 +213,80 @@ def hoh_def_with_synonyms() -> ResidueDefinition:
 
 
 @pytest.fixture
+def gly_def_neutral() -> ResidueDefinition:
+    atoms = (
+        AtomDefinition.with_defaults(name="N", symbol="N"),
+        AtomDefinition.with_defaults(name="CA", symbol="C", stereo="R"),
+        AtomDefinition.with_defaults(name="C", symbol="C"),
+        AtomDefinition.with_defaults(name="O", symbol="O"),
+        AtomDefinition.with_defaults(name="HA1", symbol="H"),
+        AtomDefinition.with_defaults(name="OXT", symbol="O", leaving=True),
+        AtomDefinition.with_defaults(name="H", symbol="H"),
+        AtomDefinition.with_defaults(name="H2", symbol="H", leaving=True),
+        AtomDefinition.with_defaults(name="HA2", symbol="H"),
+        AtomDefinition.with_defaults(name="HXT", symbol="H", leaving=True),
+    )
+
+    bonds = (
+        BondDefinition.with_defaults("N", "CA"),
+        BondDefinition.with_defaults("N", "H"),
+        BondDefinition.with_defaults("N", "H2"),
+        BondDefinition.with_defaults("CA", "C"),
+        BondDefinition.with_defaults("CA", "HA1"),
+        BondDefinition.with_defaults("CA", "HA2"),
+        BondDefinition.with_defaults("C", "O", order=2),
+        BondDefinition.with_defaults("C", "OXT"),
+        BondDefinition.with_defaults("OXT", "HXT"),
+    )
+
+    return ResidueDefinition(
+        atoms=atoms,
+        bonds=bonds,
+        crosslink=None,
+        linking_bond=PEPTIDE_BOND,
+        description="GLYCINE",
+        residue_name="GLY",
+    )
+
+
+@pytest.fixture
+def gly_def_zwitterionic() -> ResidueDefinition:
+    atoms = (
+        AtomDefinition.with_defaults(name="N", symbol="N", charge=1),
+        AtomDefinition.with_defaults(name="CA", symbol="C", stereo="R"),
+        AtomDefinition.with_defaults(name="C", symbol="C"),
+        AtomDefinition.with_defaults(name="O", symbol="O"),
+        AtomDefinition.with_defaults(name="HA1", symbol="H"),
+        AtomDefinition.with_defaults(name="OXT", symbol="O", leaving=True, charge=-1),
+        AtomDefinition.with_defaults(name="H", symbol="H"),
+        AtomDefinition.with_defaults(name="H2", symbol="H", leaving=True),
+        AtomDefinition.with_defaults(name="H3", symbol="H"),
+        AtomDefinition.with_defaults(name="HA2", symbol="H"),
+    )
+
+    bonds = (
+        BondDefinition.with_defaults("N", "CA"),
+        BondDefinition.with_defaults("N", "H"),
+        BondDefinition.with_defaults("N", "H2"),
+        BondDefinition.with_defaults("N", "H3"),
+        BondDefinition.with_defaults("CA", "C"),
+        BondDefinition.with_defaults("CA", "HA1"),
+        BondDefinition.with_defaults("CA", "HA2"),
+        BondDefinition.with_defaults("C", "O", order=2),
+        BondDefinition.with_defaults("C", "OXT"),
+    )
+
+    return ResidueDefinition(
+        atoms=atoms,
+        bonds=bonds,
+        crosslink=None,
+        linking_bond=PEPTIDE_BOND,
+        description="GLYCINE",
+        residue_name="GLY",
+    )
+
+
+@pytest.fixture
 def cys_match(cys_def: ResidueDefinition) -> ResidueMatch:
     return ResidueMatch(
         residue_definition=cys_def,

--- a/openff/pablo/_tests/test_residue.py
+++ b/openff/pablo/_tests/test_residue.py
@@ -316,3 +316,156 @@ class TestResidueDefinition:
         cys_def: ResidueDefinition,
     ):
         assert cys_def.posterior_bond_linking_atom == "C"
+
+    def test_is_isomorphic_to(
+        self,
+        cys_def: ResidueDefinition,
+        cys_def_deprotonated_sidechain: ResidueDefinition,
+    ):
+        assert cys_def._is_isomorphic_to(cys_def)
+        cys_def_shuffled_atoms = cys_def.replace(
+            atoms=cys_def.atoms[5:] + cys_def.atoms[:5],
+        )
+        cys_def_shuffled_bonds = cys_def.replace(
+            bonds=cys_def.bonds[5:] + cys_def.bonds[:5],
+        )
+        assert cys_def._is_isomorphic_to(cys_def_shuffled_atoms)
+        assert cys_def != cys_def_shuffled_atoms
+        assert cys_def._is_isomorphic_to(cys_def_shuffled_bonds)
+        assert cys_def != cys_def_shuffled_bonds
+        assert not cys_def._is_isomorphic_to(cys_def_deprotonated_sidechain)
+
+    def test_deprotonated_at_cooh(self):
+        cooh = ResidueDefinition.from_smiles(
+            "[H:1][C:2](=[O:3])[O:4][H:5]",
+            {1: "HC", 2: "C", 3: "O", 4: "OH", 5: "HO"},
+            "COOH",
+        )
+        coo = ResidueDefinition.from_smiles(
+            "[H:1][C:2](=[O:3])[O-:4]",
+            {1: "HC", 2: "C", 3: "O", 4: "OH"},
+            "COO",
+        )
+
+        assert cooh.deprotonated_at("HO")._is_isomorphic_to(coo)
+
+    def test_protonated_at_cooh(self):
+        cooh = ResidueDefinition.from_smiles(
+            "[H:1][C:2](=[O:3])[O:4][H:5]",
+            {1: "HC", 2: "C", 3: "O", 4: "OH", 5: "HO"},
+            "COOH",
+        )
+        coo = ResidueDefinition.from_smiles(
+            "[H:1][C:2](=[O:3])[O-:4]",
+            {1: "HC", 2: "C", 3: "O", 4: "OH"},
+            "COO",
+        )
+
+        assert coo.protonated_at("OH", "HO")._is_isomorphic_to(cooh)
+
+    def test_protonated_at_oh(self):
+        hydroxide_ion = ResidueDefinition(
+            atoms=(
+                AtomDefinition.with_defaults("O", "O", charge=-1),
+                AtomDefinition.with_defaults("H1", "H"),
+            ),
+            bonds=(BondDefinition.with_defaults("H1", "O"),),
+            crosslink=None,
+            linking_bond=None,
+            description="HYDROXIDE ION",
+            residue_name="OH-",
+        )
+        water_from_hydroxide = hydroxide_ion.protonated_at("O", "H2")
+        assert water_from_hydroxide.to_openff_molecule().is_isomorphic_with(
+            Molecule.from_smiles("O"),
+        )
+
+    def test_protonated_at_fails_on_synonym_clash(self):
+        oh_resdef = ResidueDefinition(
+            atoms=(
+                AtomDefinition.with_defaults("O", "O", charge=-1),
+                AtomDefinition.with_defaults("H1", "H", synonyms=["H2"]),
+            ),
+            bonds=(BondDefinition.with_defaults("H1", "O"),),
+            crosslink=None,
+            linking_bond=None,
+            description="HYDROXIDE ION",
+            residue_name="OH-",
+        )
+        assert "H2" in oh_resdef.name_to_atom
+        with pytest.raises(ValueError):
+            oh_resdef.protonated_at("O", "H2")
+
+    @pytest.mark.parametrize("ignore_synonym_clashes", [True, False])
+    def test_protonated_at_fails_on_canonical_clash(
+        self,
+        ignore_synonym_clashes: bool,
+    ):
+        with pytest.raises(ValueError):
+            ResidueDefinition(
+                atoms=(
+                    AtomDefinition.with_defaults("O", "O", charge=-1),
+                    AtomDefinition.with_defaults("H", "H"),
+                ),
+                bonds=(BondDefinition.with_defaults("H", "O"),),
+                crosslink=None,
+                linking_bond=None,
+                description="HYDROXIDE ION",
+                residue_name="OH-",
+            ).protonated_at("O", "H", ignore_synonym_clashes=ignore_synonym_clashes)
+
+    def test_deprotonated_at_cys_sidechain(
+        self,
+        cys_def: ResidueDefinition,
+        cys_def_deprotonated_sidechain: ResidueDefinition,
+    ):
+        assert cys_def.deprotonated_at("HG")._is_isomorphic_to(
+            cys_def_deprotonated_sidechain,
+        )
+
+    def test_deprotonated_at_gly_backbones(
+        self,
+        gly_def_neutral: ResidueDefinition,
+        gly_def_zwitterionic: ResidueDefinition,
+    ):
+        assert gly_def_neutral.deprotonated_at("HXT")._is_isomorphic_to(
+            gly_def_zwitterionic.deprotonated_at("H3"),
+        )
+
+    def test_protonated_at_gly_backbones(
+        self,
+        gly_def_neutral: ResidueDefinition,
+        gly_def_zwitterionic: ResidueDefinition,
+    ):
+        assert gly_def_neutral.protonated_at("N", "H3")._is_isomorphic_to(
+            gly_def_zwitterionic.protonated_at("OXT", "HXT"),
+        )
+
+    def test_vary_protonation_gly_backbones(
+        self,
+        gly_def_neutral: ResidueDefinition,
+        gly_def_zwitterionic: ResidueDefinition,
+    ):
+        from_neutral = sorted(
+            gly_def_neutral.vary_protonation(
+                acidic=["HXT"],
+                basic=[("N", "H3")],
+            ),
+            key=lambda resdef: sorted([atom.name for atom in resdef.atoms]),
+        )
+        from_zwitterionic = sorted(
+            gly_def_zwitterionic.vary_protonation(
+                acidic=["H3"],
+                basic=[("OXT", "HXT")],
+            ),
+            key=lambda resdef: sorted([atom.name for atom in resdef.atoms]),
+        )
+
+        assert len(from_neutral) == 4
+        assert len(from_zwitterionic) == 4
+
+        for resdef_from_neutral, resdef_from_zwitterionic in zip(
+            from_neutral,
+            from_zwitterionic,
+        ):
+            assert resdef_from_zwitterionic._is_isomorphic_to(resdef_from_neutral)

--- a/openff/pablo/ccd/patches.py
+++ b/openff/pablo/ccd/patches.py
@@ -2,11 +2,9 @@
 Patches to add essential features to the CCD.
 """
 
-from itertools import combinations
-
 from openff.pablo.chem import DISULFIDE_BOND
 
-from .._utils import flatten, unwrap
+from .._utils import unwrap
 from ..residue import (
     AtomDefinition,
     BondDefinition,
@@ -163,110 +161,11 @@ def add_protonation_variants(res: ResidueDefinition) -> list[ResidueDefinition]:
     this means a residue with ``n`` abstractable hydrogens and ``m`` acidic atoms
     will have ``2**(n+m)`` variants.
     """
-    return list(
-        flatten(
-            add_protonated_variants(deprotonated_variant)
-            for deprotonated_variant in add_deprotonated_variants(res)
-        ),
+    return res.vary_protonation(
+        acidic=ACIDIC_PROTONS.get(res.residue_name, []),
+        basic=BASIC_ATOMS.get(res.residue_name, []),
+        ignore_synonym_clashes=True,
     )
-
-
-def add_deprotonated_variants(res: ResidueDefinition) -> list[ResidueDefinition]:
-    """Add protonation variants from the ACIDIC_PROTONS constant"""
-    deprotonations: list[tuple[str, str]] = []
-    for hydrogen in ACIDIC_PROTONS.get(res.residue_name, []):
-        bonded_atoms: list[str] = []
-        for bond in res.bonds:
-            if bond.atom1 == hydrogen:
-                bonded_atoms.append(bond.atom2)
-            elif bond.atom2 == hydrogen:
-                bonded_atoms.append(bond.atom1)
-
-        if len(bonded_atoms) != 1:
-            raise ValueError(
-                f"should be exactly 1 bonded atom to abstracted proton {hydrogen}, found {len(bonded_atoms)} in {res.description}",
-            )
-        deprotonations.append((hydrogen, bonded_atoms[0]))
-
-    variants: list[ResidueDefinition] = [res]
-    for i in range(len(deprotonations)):
-        for combination in combinations(deprotonations, i + 1):
-            hydrogens, partners = zip(*combination)
-
-            bonds: list[BondDefinition] = [
-                bond
-                for bond in res.bonds
-                if bond.atom1 not in hydrogens and bond.atom2 not in hydrogens
-            ]
-
-            atoms: list[AtomDefinition] = []
-            for atom in res.atoms:
-                if atom.name in partners:
-                    atoms.append(atom.replace(charge=atom.charge - 1))
-                elif atom.name in hydrogens:
-                    if atom.symbol != "H":
-                        raise ValueError(
-                            "Elements of PROTONATION_VARIANTS values must be hydrogens",
-                        )
-                else:
-                    atoms.append(atom)
-
-            variants.append(
-                res.replace(
-                    atoms=atoms,
-                    bonds=bonds,
-                    description=res.description + f" -{' -'.join(hydrogens)}",
-                ),
-            )
-
-    return variants
-
-
-def add_protonated_variants(res: ResidueDefinition) -> list[ResidueDefinition]:
-    """Add protonation variants from the BASIC_ATOMS constant"""
-    protonations = BASIC_ATOMS.get(res.residue_name, [])
-
-    variants: list[ResidueDefinition] = [res]
-    for i in range(len(protonations)):
-        for combination in combinations(protonations, i + 1):
-            bonds = [*res.bonds]
-            atoms = [*res.atoms]
-            for heavy_atom, hydrogen in combination:
-                bonds.append(
-                    BondDefinition(
-                        heavy_atom,
-                        hydrogen,
-                        order=1,
-                        aromatic=False,
-                        stereo=None,
-                    ),
-                )
-
-                atoms.append(
-                    AtomDefinition(
-                        name=hydrogen,
-                        synonyms=(),
-                        symbol="H",
-                        leaving=False,
-                        charge=0,
-                        aromatic=False,
-                        stereo=None,
-                    ),
-                )
-                for i, atom in enumerate(res.atoms):
-                    if atom.name == heavy_atom:
-                        atoms[i] = atom.replace(charge=atom.charge + 1)
-
-            _partners, hydrogens = zip(*combination)
-            variants.append(
-                res.replace(
-                    atoms=atoms,
-                    bonds=bonds,
-                    description=res.description + f" +{' +'.join(hydrogens)}",
-                ),
-            )
-
-    return variants
 
 
 def add_synonyms(res: ResidueDefinition) -> list[ResidueDefinition]:

--- a/openff/pablo/residue.py
+++ b/openff/pablo/residue.py
@@ -562,16 +562,21 @@ class ResidueDefinition:
         return molecule
 
     @cached_property
+    def canonical_name_to_atom(self) -> dict[str, AtomDefinition]:
+        """Map from each atoms' name and synonyms to the atom definition."""
+        return {atom.name: atom for atom in self.atoms}
+
+    @cached_property
     def name_to_atom(self) -> dict[str, AtomDefinition]:
         """Map from each atoms' name and synonyms to the atom definition."""
-        mapping = {atom.name: atom for atom in self.atoms}
+        mapping = self.canonical_name_to_atom
         canonical_names = set(mapping)
         for atom in self.atoms:
             for synonym in atom.synonyms:
                 if synonym in mapping and mapping[synonym] != atom:
                     raise ValueError(
                         f"synonym {synonym} degenerately defined for canonical"
-                        + f" names {mapping[synonym]} and {atom.name} in"
+                        + f" names {mapping[synonym].name} and {atom.name} in"
                         + f" residue {self.residue_name}",
                     )
                 if synonym in canonical_names:
@@ -639,3 +644,176 @@ class ResidueDefinition:
         if self.linking_bond is None:
             raise ValueError("not a linking residue")
         return self.linking_bond.atom1
+
+    def _is_isomorphic_to(self, other: Self) -> bool:
+        """Atom and bond ordering insensitive equality test"""
+        if other.linking_bond != self.linking_bond:
+            print(other.linking_bond, "!=", self.linking_bond)
+        if other.crosslink != self.crosslink:
+            print(other.crosslink, "!=", self.crosslink)
+        if set(other.atoms) != set(self.atoms):
+            print(
+                f"{set(other.atoms)-set(self.atoms)=}\n{set(self.atoms)-set(other.atoms)=}",
+            )
+        if set(other.bonds) != set(self.bonds):
+            print(
+                f"{set(other.bonds)-set(self.bonds)=}\n{set(self.bonds)-set(other.bonds)=}",
+            )
+        return all(
+            [
+                other.linking_bond == self.linking_bond,
+                other.crosslink == self.crosslink,
+                set(other.atoms) == set(self.atoms),
+                set(other.bonds) == set(self.bonds),
+            ],
+        )
+
+    def deprotonated_at(self, name: str) -> Self:
+        """Return a copy of ``self`` with proton ``name`` abstracted.
+
+        The hydrogen with canonical name ``name`` is removed, and the formal
+        charge of the atom bonded to it is decremented. If the named atom is not
+        hydrogen, is missing, or is bonded to a number of other atoms other than
+        1, ``ValueError`` is raised.
+        """
+        try:
+            atom = self.canonical_name_to_atom[name]
+        except KeyError:
+            raise ValueError(f"Cannot deprotonate missing atom {name}")
+
+        if atom.symbol != "H":
+            raise ValueError(
+                f"Cannot deprotonate non-hydrogen atom {name}: {atom.symbol=}",
+            )
+
+        neighbours = [
+            *(bond.atom1 for bond in self.bonds if bond.atom2 == name),
+            *(bond.atom2 for bond in self.bonds if bond.atom1 == name),
+        ]
+        if len(neighbours) != 1:
+            raise ValueError(
+                f"Cannot deprotonate atom {name} bonded to {len(neighbours)} other atoms",
+            )
+        neighbour = neighbours[0]
+
+        return self.replace(
+            bonds=[bond for bond in self.bonds if name not in [bond.atom1, bond.atom2]],
+            atoms=[
+                (
+                    atom.replace(charge=atom.charge - 1)
+                    if atom.name == neighbour
+                    else atom
+                )
+                for atom in self.atoms
+                if atom.name != name
+            ],
+        )
+
+    def protonated_at(
+        self,
+        heavy_atom_name: str,
+        proton_name: str,
+        ignore_synonym_clashes: bool = False,
+    ) -> Self:
+        """Return a copy of ``self`` with ``heavy_atom_name`` protonated by ``proton_name``.
+
+        The formal charge of the atom with canonical name ``heavy_atom_name`` is
+        incremented, a new hydrogen atom named ``proton_name`` is added, and a
+        bond is created between the two named atoms.  If the heavy atom is
+        missing or the new proton name clashes with an existing name or synonym,
+        ``ValueError`` is raised. The new atom has the same value for the
+        ``leaving`` attribute as the heavy atom. The synonym clash check may be
+        suppressed with the ``ignore_synonym_clashes`` argument, but the
+        canonical names are always checked.
+        """
+        try:
+            heavy_atom = self.canonical_name_to_atom[heavy_atom_name]
+        except KeyError:
+            raise ValueError(f"Cannot protonate missing atom {heavy_atom_name}")
+        if any(
+            [
+                (ignore_synonym_clashes and proton_name in self.canonical_name_to_atom),
+                (not ignore_synonym_clashes and proton_name in self.name_to_atom),
+            ],
+        ):
+            raise ValueError(
+                f"name {proton_name} clashes with existing name in residue",
+            )
+
+        return self.replace(
+            bonds=[
+                *self.bonds,
+                BondDefinition.with_defaults(heavy_atom_name, proton_name),
+            ],
+            atoms=[
+                *(
+                    (
+                        atom.replace(charge=atom.charge + 1)
+                        if atom.name == heavy_atom_name
+                        else atom
+                    )
+                    for atom in self.atoms
+                ),
+                AtomDefinition.with_defaults(
+                    proton_name,
+                    "H",
+                    leaving=heavy_atom.leaving,
+                ),
+            ],
+        )
+
+    def vary_protonation(
+        self,
+        *,
+        acidic: Iterable[str],
+        # Each element specifies an atom name to remove, decrementing the formal
+        # charge on the neighbouring heavy atom. Multiply bonded or non-hydrogen
+        # atoms raise an error.
+        basic: Iterable[tuple[str, str]],
+        # Each tuple specifies an atom name to protonate (increment the formal
+        # charge and form a bond) and the name of the added proton
+        ignore_synonym_clashes: bool = False,
+    ) -> list[Self]:
+        """
+        Compute all combinations of the specified protonation variants
+
+        The first element of the returned list is guaranteed to be the unmodified
+        starting residue definition; to get a list of just the new variants, use
+        ``resdef.vary_protonation(...)[1:]``.
+
+        Note that all combinations of protonations and deprotonations are
+        generated; this means that if ``acidic`` has length ``n`` and ``bassic``
+        has length ``m``, ``2**(n+m)`` variants will be generated.
+
+        Parameters
+        ==========
+        acidic
+            Each element specifies an atom name to remove, decrementing the
+            formal charge on the neighbouring heavy atom. Multiply bonded,
+            unbonded, missing or non-hydrogen atoms raise ``ValueError``.
+        basic
+            Each tuple specifies an atom name to protonate (increment the formal
+            charge and form a bond) and the name of the added proton. Missing
+            heavy atoms or new atom names that clash with existing names raise
+            ``ValueError``.
+        ignore_synonym_clashes
+            If set to ``True``, protons added by the ``basic`` argument may have
+            names that clash with the synonyms of other atoms. This can be
+            useful in the early stages of a multi-step residue definition
+            patching process. Added protons may never have names that clash
+            with the canonical names of other atoms.
+        """
+        variants = [self]
+        for proton_to_remove in acidic:
+            for variant in list(variants):
+                variants.append(variant.deprotonated_at(proton_to_remove))
+        for atom_to_protonate, name_of_proton in basic:
+            for variant in list(variants):
+                variants.append(
+                    variant.protonated_at(
+                        atom_to_protonate,
+                        name_of_proton,
+                        ignore_synonym_clashes=ignore_synonym_clashes,
+                    ),
+                )
+        return variants

--- a/openff/pablo/residue.py
+++ b/openff/pablo/residue.py
@@ -686,10 +686,7 @@ class ResidueDefinition:
                 f"Cannot deprotonate non-hydrogen atom {name}: {atom.symbol=}",
             )
 
-        neighbours = [
-            *(bond.atom1 for bond in self.bonds if bond.atom2 == name),
-            *(bond.atom2 for bond in self.bonds if bond.atom1 == name),
-        ]
+        neighbours = list(self.atoms_bonded_to(name))
         if len(neighbours) != 1:
             raise ValueError(
                 f"Cannot deprotonate atom {name} bonded to {len(neighbours)} other atoms",
@@ -782,7 +779,7 @@ class ResidueDefinition:
         ``resdef.vary_protonation(...)[1:]``.
 
         Note that all combinations of protonations and deprotonations are
-        generated; this means that if ``acidic`` has length ``n`` and ``bassic``
+        generated; this means that if ``acidic`` has length ``n`` and ``basic``
         has length ``m``, ``2**(n+m)`` variants will be generated.
 
         Parameters


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

May fix #77 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Adds `protonated_at`, `deprotonated_at`, and `vary_protonation` methods to `ResidueDefinition`
 - Replaces the complex protonation state patching code with a simple call to `vary_protonation`


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
