### PR TITLE
Improve docstrings and errors for CcdCache

### DIFF
--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -12,6 +12,7 @@ dependencies:
   - sphinx-notfound-page
   - autodoc-pydantic
   - sphinx-click
+  - imghdr
 
   # Imports
   - openff-units

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # Base depends
-  - python>=3.11
+  - python>=3.11,<3.13
   - pip
 
   # Documentation
@@ -12,7 +12,6 @@ dependencies:
   - sphinx-notfound-page
   - autodoc-pydantic
   - sphinx-click
-  - imghdr
 
   # Imports
   - openff-units

--- a/openff/pablo/_tests/conftest.py
+++ b/openff/pablo/_tests/conftest.py
@@ -190,6 +190,15 @@ def hoh_def() -> ResidueDefinition:
 
 
 @pytest.fixture
+def hooh_def() -> ResidueDefinition:
+    return ResidueDefinition.from_smiles(
+        "[H:1][O:2][O:3][H:4]",
+        {1: "H1", 2: "O1", 3: "O2", 4: "H2"},
+        "HOOH",
+    )
+
+
+@pytest.fixture
 def hoh_def_with_synonyms() -> ResidueDefinition:
     atoms = (
         AtomDefinition.with_defaults(name="H1", symbol="H", synonyms=["HA"]),

--- a/openff/pablo/_tests/test_ccd.py
+++ b/openff/pablo/_tests/test_ccd.py
@@ -62,3 +62,20 @@ def test_ccdcache_can_load_residues_with_internet(resname: str):
 )
 def test_ccdcache_can_load_common_residues_without_internet(resname: str):
     CCD_RESIDUE_DEFINITION_CACHE[resname]
+
+
+@pytest.mark.parametrize(
+    ("resname", "expected_message"),
+    [
+        ("01", "unknown and absent from CCD"),
+        ("UNK", "reserved residue name"),
+        ("UNL", "reserved residue name"),
+    ],
+)
+def test_ccdcache_gives_clear_errors(resname: str, expected_message: str):
+    with pytest.raises(
+        KeyError,
+        match=expected_message,
+        check=lambda e: e.args == (resname, expected_message),
+    ):
+        CCD_RESIDUE_DEFINITION_CACHE[resname]

--- a/openff/pablo/_tests/test_ccd.py
+++ b/openff/pablo/_tests/test_ccd.py
@@ -1,6 +1,7 @@
 import pytest
 
 from openff.pablo.ccd import CCD_RESIDUE_DEFINITION_CACHE
+from openff.pablo.residue import ResidueDefinition
 
 
 @pytest.mark.parametrize(
@@ -79,3 +80,35 @@ def test_ccdcache_gives_clear_errors(resname: str, expected_message: str):
         check=lambda e: e.args == (resname, expected_message),
     ):
         CCD_RESIDUE_DEFINITION_CACHE[resname]
+
+
+def test_ccdcache_with(hooh_def: ResidueDefinition, hoh_def: ResidueDefinition):
+    assert "HOOH" not in CCD_RESIDUE_DEFINITION_CACHE
+    new_ccdcache = CCD_RESIDUE_DEFINITION_CACHE.with_([hooh_def])
+    assert new_ccdcache is not CCD_RESIDUE_DEFINITION_CACHE
+    assert "HOOH" in new_ccdcache
+    assert "HOOH" not in CCD_RESIDUE_DEFINITION_CACHE
+    assert new_ccdcache["HOOH"] == [hooh_def]
+
+    assert "HOH" in CCD_RESIDUE_DEFINITION_CACHE
+    assert CCD_RESIDUE_DEFINITION_CACHE["HOH"] != hoh_def
+    new_ccdcache = CCD_RESIDUE_DEFINITION_CACHE.with_({"HOH": [hoh_def]})
+    assert new_ccdcache is not CCD_RESIDUE_DEFINITION_CACHE
+    assert new_ccdcache["HOH"] == [*CCD_RESIDUE_DEFINITION_CACHE["HOH"], hoh_def]
+
+
+def test_ccdcache_with_replaced(hoh_def: ResidueDefinition):
+    assert "HOH" in CCD_RESIDUE_DEFINITION_CACHE
+    assert CCD_RESIDUE_DEFINITION_CACHE["HOH"] != hoh_def
+    new_ccdcache = CCD_RESIDUE_DEFINITION_CACHE.with_replaced({"HOH": [hoh_def]})
+    assert new_ccdcache is not CCD_RESIDUE_DEFINITION_CACHE
+    assert new_ccdcache["HOH"] == [hoh_def]
+
+
+def test_ccdcache_without(hooh_def: ResidueDefinition):
+    assert "HOOH" not in CCD_RESIDUE_DEFINITION_CACHE
+    ccdcache_with_hooh = CCD_RESIDUE_DEFINITION_CACHE.with_([hooh_def])
+    new_ccdcache = ccdcache_with_hooh.without({"HOOH"})
+    assert new_ccdcache is not ccdcache_with_hooh
+    assert "HOOH" not in new_ccdcache
+    assert "HOOH" in ccdcache_with_hooh

--- a/openff/pablo/ccd/__init__.py
+++ b/openff/pablo/ccd/__init__.py
@@ -23,6 +23,7 @@ from .patches import (
     fix_caps,
     patch_his_sidechain_zwitterion,
     set_hop3_leaving,
+    strip_linkless_leavers,
 )
 
 __all__ = [
@@ -34,7 +35,7 @@ __all__ = [
 # TODO: Replace these patches with CONECT records?
 CCD_RESIDUE_DEFINITION_CACHE: CcdCache = CcdCache(
     # TODO: Use a proper resource setup for this
-    [Path(__file__).parent / "data/ccd_cache"],
+    library_paths=[Path(__file__).parent / "data/ccd_cache"],
     patches=[
         {
             "ACE": fix_caps,
@@ -66,6 +67,7 @@ CCD_RESIDUE_DEFINITION_CACHE: CcdCache = CcdCache(
         },
         {"*": disambiguate_alt_ids},
         {"*": add_synonyms},
+        {"*": strip_linkless_leavers},
         {
             "HIS": patch_his_sidechain_zwitterion,
             "ARG": delete_doubly_deprotonated_arginine,

--- a/openff/pablo/ccd/_ccdcache.py
+++ b/openff/pablo/ccd/_ccdcache.py
@@ -9,6 +9,8 @@ from urllib.request import HTTPError, urlopen
 import xdg.BaseDirectory as xdg_base_dir
 from openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
 
+from openff.pablo._utils import flatten
+
 from ..chem import PEPTIDE_BOND, PHOSPHODIESTER_BOND
 from ..residue import (
     AtomDefinition,
@@ -26,6 +28,44 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
     """
     Caches, patches, and presents the CCD as a Python ``Mapping``.
 
+    This class is a wrapper around a ``dict`` that stores residue definitions.
+    When a residue is requested via the indexing syntax (for example,
+    ``my_ccd_cache["ALA"]``) or the ``in`` operator, this dictionary is checked
+    first. If the residue is not present, the CCD is then checked. If the
+    residue cannot be retrieved from the inner ``dict`` or the CCD, a
+    ``KeyError`` is raised or ``False`` is returned as appropriate.
+
+    Iterating over the mapping, checking its length, or otherwise treating the
+    ``CcdCache`` as a mapping other than with the indexing syntax or ``in``
+    operator works only on the inner ``dict``. As a result, accessing
+    a residue via indexing may return a value even if these other methods
+    suggest it won't.
+
+    ``CcdCache`` can apply patches to the entries it downloads from the CCD.
+    This is used to work around known errors, deficiencies and inconsistencies
+    in the CCD definitions. Patches are specified as functions that take a
+    single residue definition and return a list of them.
+
+    The ``extra_definitions`` and the ``with_()`` and ``with_replaced`` methods
+    allow custom definitions to be added to a ``CcdCache``. These custom
+    definitions are not patched. Since they are stored alongside cached entries
+    in the inner dictionary, custom definitions supercede any that have not
+    already been downloaded from the CCD.
+
+    When a CCD entry is downloaded, the corresponding CIF file is stored in the
+    ``cache_path``. This means that each entry will be downloaded only once,
+    even across multiple Python invocations. All entries in the cache are loaded
+    (and patches applied) when a new ``CcdCache`` is created. ``CcdCache``
+    assumes that the files in the cache path were downloaded from the CCD and
+    may do unexpected things if they are edited by hand.
+
+    Users may provide additional CCD entries by specifying library paths. By
+    default, this is used to ship commonly used residues with Pablo. At the
+    moment, patches are applied to files in library paths, but it is likely that
+    in the future they won't be and residues shipped with Pablo will be shipped
+    pre-patched to speed up load times. Like with the cache, files from library
+    paths are loaded when a ``CcdCache`` is created.
+
     Accessing the CCD requires internet access. Without internet access, entries
     from the cache or library paths can still be loaded, as can any entries
     added to an instance of this class.
@@ -37,23 +77,31 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         searched.
     cache_path
         The path to which to download CCD entries. This path is searched in
-        addition to ``library_paths``. There is no need to include this path
-        in ``library_paths``, but it doesn't hurt if you do.
+        addition to ``library_paths``.
     preload
         A list of residue names to download when initializing the class.
     patches
-        Functions to call on the given ``ResidueDefinitions`` before they are
-        returned. An iterable of maps from residue names each to a single
-        callable. Each map is applied to residues with the given name in the
-        order they are iterated over. The patch corresponding to key ``"*"``
-        will be applied to all residues before the more specific patches in its
-        map.
+        Functions to call on ``ResidueDefinitions`` downloaded from the CCD
+        before they are returned or added to the inner `dict``. An iterable of
+        maps from residue names each to a single callable. Each map is applied
+        to residues with the given name in the order they are iterated over. Any
+        patches corresponding to key ``"*"`` will be applied to all residues
+        before the more specific patches in its map.
     extra_definitions
         Additional residue definitions to add to the cache. Note that patches
         are not applied to these definitions.
     """
 
-    # TODO: Methods for adding entries from mapped SMILES
+    # TODO: remove library_paths in favour of loading pre-patched entries
+    #       distributed with Pablo via extra_definitions
+
+    # TODO: Consider storing extra definitions and patched CCD entries in
+    #       separate inner dicts to make behaviour less dependent on access
+    #       sequencing
+
+    # TODO: Make cache_path optional
+
+    # TODO: Compress the on-disk cache
 
     def __init__(
         self,
@@ -86,7 +134,7 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
 
         for path in self._glob("*.cif"):
             try:
-                self._add_definition_from_str(path.read_text())
+                self._add_definition_from_str(path.read_text(), patch=True)
             except Exception:
                 # If adding a file fails, skip it - we want an error at runtime, not importtime
                 pass
@@ -113,20 +161,30 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         except KeyError:
             pass
 
-        # Don't check the library or cache; they were loaded in __init__, and
+        # Don't check the library; it was loaded in __init__, and
         # trying to hot-load a definition that's already in self._definitions
         # would be very confusing.
 
-        # If it's a residue id that could be in the CCD, try to download it
+        # If it's a residue id that could be in the CCD, try to download it.
+        # We should check the cache here in case this file has been downloaded
+        # since this CcdCache was created - say, in a separate process, or
+        # another CcdCache - but this is done by _add_definition_from_ccd()
         try:
-            return self._add_definition_from_str(
-                self._download_cif(res_name),
-                res_name=res_name,
-            )
+            return self._add_definition_from_ccd(res_name)
         except HTTPError:
             raise KeyError(res_name, "unknown and absent from CCD")
         except URLError:
             raise KeyError(res_name, "unknown and CCD could not be accessed")
+
+    def _add_definition_from_ccd(self, res_name: str) -> list[ResidueDefinition]:
+        """Add a definition by retrieving it from the CCD (or the cache)"""
+        cache_path = self._cache_path / f"{res_name}.cif"
+        if cache_path.is_file():
+            s = cache_path.read_text()
+        else:
+            s = self._download_cif(res_name)
+
+        return self._add_definition_from_str(s, res_name=res_name, patch=True)
 
     def _apply_patches(
         self,
@@ -156,24 +214,20 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         self,
         s: str,
         res_name: str | None = None,
+        patch: bool = False,
     ) -> list[ResidueDefinition]:
         definition = self._res_def_from_ccd_str(s)
-        return self._add_and_patch_definition(definition, res_name)
 
-    def _add_and_patch_definition(
-        self,
-        definition: ResidueDefinition,
-        res_name: str | None = None,
-    ) -> list[ResidueDefinition]:
         if res_name is None:
             res_name = definition.residue_name.upper()
 
-        return self._add_definitions(self._apply_patches(definition), res_name)
+        return self._add_definitions((definition,), res_name, patch=patch)
 
     def _add_definitions(
         self,
         definitions: Iterable[ResidueDefinition],
         res_name: str,
+        patch: bool = False,
     ) -> list[ResidueDefinition]:
         for definition in definitions:
             if res_name != definition.residue_name.upper():
@@ -181,6 +235,10 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
                     f"ResidueDefinition {definition.residue_name}"
                     + f" ({definition.description}) must have residue name {res_name}",
                 )
+
+        if patch:
+            definitions = flatten(map(self._apply_patches, definitions))
+
         stored_definitions = self._definitions.setdefault(res_name, [])
         stored_definitions.extend(definitions)
         return stored_definitions
@@ -307,7 +365,7 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
             return True
         if not isinstance(value, str):
             raise TypeError(
-                f"CcdCache contains residue names of type str, not {type(value)}",
+                f"CcdCache keys are residue names of type str, not {type(value)}",
             )
 
         try:
@@ -337,7 +395,7 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         latter case, the residue names are taken from the residue definitions
         themselves.
 
-        Note that patches are not applied to the additional definitions.
+        Note that patches are not applied to the new definitions.
 
         Examples
         ========
@@ -374,6 +432,10 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         >>> len(my_ccd_cache["ABU"]) - len(CCD_RESIDUE_DEFINITION_CACHE["ABU"])
         3
 
+        See Also
+        ========
+        with_replaced, without
+
         """
         if not isinstance(definitions, Mapping):
             definitions_map: dict[str, list[ResidueDefinition]] = {}
@@ -384,6 +446,53 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         new = deepcopy(self)
         for resname, resdefs in definitions.items():
             new._add_definitions(resdefs, resname)
+        return new
+
+    def with_replaced(
+        self,
+        definitions: Mapping[str, Sequence[ResidueDefinition]],
+    ) -> Self:
+        """
+        Get a new ``CcdCache`` with replaced definitions of some residue names.
+
+        Similar to ``with_``, but does not retain existing definitions for the
+        specified residue names. All residue names that are keys of
+        ``definitions`` are removed from the new ``CcdCache`` before adding the
+        new definitions.
+
+        Note that patches are not applied to the new definitions.
+
+        See Also
+        ========
+        with_, without
+
+        """
+        new = deepcopy(self)
+        for resname, resdefs in definitions.items():
+            del new._definitions[resname]
+            new._add_definitions(resdefs, resname)
+        return new
+
+    def without(
+        self,
+        residue_names: Iterable[str],
+    ) -> Self:
+        """
+        Get a new ``CcdCache`` with some residue names removed.
+
+        All definitions for each of the given residue names will not be present
+        in the new cache. Note that residues that are in the CCD will still be
+        returned when they are requested, as long as they can be re-downloaded
+        or found in the cache.
+
+        See Also
+        ========
+        with_replaced, with_
+
+        """
+        new = deepcopy(self)
+        for resname in residue_names:
+            del new._definitions[resname]
         return new
 
 

--- a/openff/pablo/ccd/_ccdcache.py
+++ b/openff/pablo/ccd/_ccdcache.py
@@ -3,7 +3,8 @@ from copy import deepcopy
 from io import StringIO
 from pathlib import Path
 from typing import Self, no_type_check
-from urllib.request import urlopen
+from urllib.error import URLError
+from urllib.request import HTTPError, urlopen
 
 import xdg.BaseDirectory as xdg_base_dir
 from openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
@@ -25,20 +26,28 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
     """
     Caches, patches, and presents the CCD as a Python ``Mapping``.
 
-    This requires internet access to work.
+    Accessing the CCD requires internet access. Without internet access, entries
+    from the cache or library paths can still be loaded, as can any entries
+    added to an instance of this class.
 
     Parameters
     ==========
-    path
-        The path to which to download CCD entries.
+    library_paths
+        Paths to search for user-provided or packaged CCD entries. All paths are
+        searched.
+    cache_path
+        The path to which to download CCD entries. This path is searched in
+        addition to ``library_paths``. There is no need to include this path
+        in ``library_paths``, but it doesn't hurt if you do.
     preload
         A list of residue names to download when initializing the class.
     patches
         Functions to call on the given ``ResidueDefinitions`` before they are
-        returned. A map from residue names to a single callable. The patch
-        corresponding to key ``"*"`` will be applied to all residues before the
-        more specific patches. Use :py:func:`combine_patches` to combine
-        multiple patches into one.
+        returned. An iterable of maps from residue names each to a single
+        callable. Each map is applied to residues with the given name in the
+        order they are iterated over. The patch corresponding to key ``"*"``
+        will be applied to all residues before the more specific patches in its
+        map.
     extra_definitions
         Additional residue definitions to add to the cache. Note that patches
         are not applied to these definitions.
@@ -65,7 +74,7 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         self._cache_path = cache_path.resolve()
         self._cache_path.mkdir(parents=True, exist_ok=True)
 
-        self._library_paths = [path.resolve() for path in library_paths]
+        self._library_paths = {path.resolve() for path in library_paths}
 
         self._definitions: dict[str, list[ResidueDefinition]] = {}
         self._patches: list[
@@ -89,33 +98,35 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
                 # If a preload fails, skip it - we want an error at runtime, not importtime
                 pass
 
-        self._extra_definitions_set = False
         for resname, resdefs in extra_definitions.items():
-            self._extra_definitions_set = True
             self._add_definitions(resdefs, resname)
-
-    def __repr__(self):
-        return (
-            f"CcdCache(path={self._cache_path},"
-            + f" preload={list(self._definitions)},"
-            + f" patches={self._patches!r}"
-            + (", extra_definitions={...}" if self._extra_definitions_set else "")
-            + ")"
-        )
 
     def __getitem__(self, key: str) -> list[ResidueDefinition]:
         res_name = key.upper()
-        if res_name in ["UNK", "UNL"]:
+        if res_name in ["UNK", "UNL"] and res_name not in self._definitions:
             # These residue names are reserved for unknown ligands/peptide residues
-            raise KeyError(res_name)
-        if res_name not in self._definitions:
-            try:
-                s = (self._cache_path / f"{res_name.upper()}.cif").read_text()
-            except Exception:
-                s = self._download_cif(res_name)
+            raise KeyError(res_name, "reserved residue name")
 
-            self._add_definition_from_str(s, res_name=res_name)
-        return self._definitions[res_name]
+        # Check the loaded definitions
+        try:
+            return self._definitions[res_name]
+        except KeyError:
+            pass
+
+        # Don't check the library or cache; they were loaded in __init__, and
+        # trying to hot-load a definition that's already in self._definitions
+        # would be very confusing.
+
+        # If it's a residue id that could be in the CCD, try to download it
+        try:
+            return self._add_definition_from_str(
+                self._download_cif(res_name),
+                res_name=res_name,
+            )
+        except HTTPError:
+            raise KeyError(res_name, "unknown and absent from CCD")
+        except URLError:
+            raise KeyError(res_name, "unknown and CCD could not be accessed")
 
     def _apply_patches(
         self,
@@ -141,32 +152,38 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
 
         return definitions
 
-    def _add_definition_from_str(self, s: str, res_name: str | None = None) -> None:
+    def _add_definition_from_str(
+        self,
+        s: str,
+        res_name: str | None = None,
+    ) -> list[ResidueDefinition]:
         definition = self._res_def_from_ccd_str(s)
-        self._add_and_patch_definition(definition, res_name)
+        return self._add_and_patch_definition(definition, res_name)
 
     def _add_and_patch_definition(
         self,
         definition: ResidueDefinition,
         res_name: str | None = None,
-    ) -> None:
+    ) -> list[ResidueDefinition]:
         if res_name is None:
             res_name = definition.residue_name.upper()
 
-        self._add_definitions(self._apply_patches(definition), res_name)
+        return self._add_definitions(self._apply_patches(definition), res_name)
 
     def _add_definitions(
         self,
         definitions: Iterable[ResidueDefinition],
         res_name: str,
-    ) -> None:
+    ) -> list[ResidueDefinition]:
         for definition in definitions:
             if res_name != definition.residue_name.upper():
                 raise ValueError(
                     f"ResidueDefinition {definition.residue_name}"
                     + f" ({definition.description}) must have residue name {res_name}",
                 )
-        self._definitions.setdefault(res_name, []).extend(definitions)
+        stored_definitions = self._definitions.setdefault(res_name, [])
+        stored_definitions.extend(definitions)
+        return stored_definitions
 
     def _download_cif(self, resname: str) -> str:
         with urlopen(
@@ -177,13 +194,29 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
         path.write_text(s)
         return s
 
-    @property
-    def _paths(self) -> Iterator[Path]:
-        yield self._cache_path
-        yield from self._library_paths
+    def _glob(
+        self,
+        pattern: str,
+        *,
+        cached: bool = True,
+        library: bool = True,
+    ) -> Iterator[Path]:
+        """
+        Get paths matching the given glob pattern from the cache and/or library
 
-    def _glob(self, pattern: str) -> Iterator[Path]:
-        for path in self._paths:
+        Parameters
+        ==========
+        pattern
+            The glob to search for
+        cached
+            Whether to look in the cache path for the glob
+        library
+            Whether to look in the library paths for the glob
+        """
+        for path in {
+            *((self._cache_path,) if cached else ()),
+            *(self._library_paths if library else ()),
+        }:
             yield from path.glob(pattern)
 
     @staticmethod
@@ -293,11 +326,63 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
 
     def with_(
         self,
-        extra_definitions: Mapping[str, Sequence[ResidueDefinition]],
+        definitions: Mapping[str, Sequence[ResidueDefinition]]
+        | Sequence[ResidueDefinition],
     ) -> Self:
+        """
+        Get a new ``CcdCache`` with additional definitions.
+
+        Definitions may be supplied as a mapping from residue names to sequences
+        of residue definitions, or as a sequence of residue definitions. In the
+        latter case, the residue names are taken from the residue definitions
+        themselves.
+
+        Note that patches are not applied to the additional definitions.
+
+        Examples
+        ========
+
+        Add a custom definition to the ``CCD_RESIDUE_DEFINITION_CACHE``. We use
+        a 4-letter residue code as they are supported by Pablo's PDB reader and
+        do not clash with the CCD's definitions.
+
+        >>> from openff.pablo import CCD_RESIDUE_DEFINITION_CACHE, ResidueDefinition
+        >>> my_ccd_cache = CCD_RESIDUE_DEFINITION_CACHE.with_([
+        ...     ResidueDefinition.from_smiles(
+        ...         "[H:1][O:2][O:3][H:4]",
+        ...         {1: "H1", 2: "O1", 3: "O2", 4: "H2"},
+        ...         "HOOH",
+        ...     )
+        ... ])
+
+        Add protonation variants of a residue by specifying acidic and basic
+        atoms.
+
+        >>> from openff.pablo import CCD_RESIDUE_DEFINITION_CACHE, ResidueDefinition
+        >>>
+        >>> # Get the GABA (γ-amino butanoic acid) residue definition from CCD
+        >>> gaba_resdef = CCD_RESIDUE_DEFINITION_CACHE["ABU"][0]
+        >>>
+        >>> # Generate the variants and add them to a new cache
+        >>> my_ccd_cache = CCD_RESIDUE_DEFINITION_CACHE.with_({
+        ...     "ABU": gaba_resdef.vary_protonation(
+        ...         acidic=["HXT"], # Atom name of abstractable proton
+        ...         basic=[("N", "H3")], # Atom to protonate, name of new proton
+        ...     )[1:], # Skip the first entry, which is already in the cache
+        ... })
+        >>> # Should have added three variants - positive, negative, zwitterion
+        >>> len(my_ccd_cache["ABU"]) - len(CCD_RESIDUE_DEFINITION_CACHE["ABU"])
+        3
+
+        """
+        if not isinstance(definitions, Mapping):
+            definitions_map: dict[str, list[ResidueDefinition]] = {}
+            for resdef in definitions:
+                definitions_map.setdefault(resdef.residue_name, []).append(resdef)
+            definitions = definitions_map
+
         new = deepcopy(self)
-        for resname, resdefs in extra_definitions.items():
-            new._extra_definitions_set = True
+        for resname, resdefs in definitions.items():
             new._add_definitions(resdefs, resname)
         return new
 

--- a/openff/pablo/ccd/patches.py
+++ b/openff/pablo/ccd/patches.py
@@ -429,3 +429,15 @@ def add_nh2_leaving_atom(
         ),
         res,
     ]
+
+
+def strip_linkless_leavers(
+    res: ResidueDefinition,
+) -> list[ResidueDefinition]:
+    """
+    Set ``leaving=False`` on all atoms if ``res`` has no linking bond or crosslink
+    """
+    if res.linking_bond is None and res.crosslink is None:
+        return [res.replace(atoms=[atom.replace(leaving=False) for atom in res.atoms])]
+    else:
+        return [res]


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #79 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Consistently give `KeyError`s with descriptive messages in `CcdCache.__get__`
 - Tests for the new errors
 - Improve (and bring up-to-date with previous PRs) docstrings on `CcdCache` and its methods
 - Some tweaks to private `CcdCache` methods
 - Support taking a sequence of residue defintions in `CcdCache.with_()` in addition to a mapping
 - Examples for how to use `CcdCache.with_()`
 - Patch CCD entries that have leaving atoms but no linking bond/crosslink


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
