### PR TITLE
Split subresidues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,7 @@ poetry.lock
 # ruff
 .ruff_cache
 
+# zed
+.zed/
+
 .ccd_cache

--- a/examples/load_pdb.ipynb
+++ b/examples/load_pdb.ipynb
@@ -225,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/openff/pablo/_matching.py
+++ b/openff/pablo/_matching.py
@@ -8,9 +8,8 @@ from openff.toolkit import Molecule
 from .residue import AtomDefinition, BondDefinition, ResidueDefinition
 
 
-# TODO: Refactor
 @dataclass(frozen=True)
-class MatchProtocol(Protocol):
+class PossibleMatchProtocol(Protocol):
     residue_definition: ResidueDefinition | str | Molecule
     index_to_atomdef: Mapping[int, AtomDefinition | None]
     is_match: ClassVar[bool]
@@ -40,7 +39,30 @@ class MatchProtocol(Protocol):
 
 
 @dataclass(frozen=True)
-class NoResidueDefinitions(MatchProtocol):
+class MatchProtocol(PossibleMatchProtocol):
+    @cached_property
+    def expects_prior_bond(self) -> bool:
+        return False
+
+    @cached_property
+    def expects_posterior_bond(self) -> bool:
+        return False
+
+    @cached_property
+    def expects_crosslink(self) -> bool:
+        return False
+
+    def agrees_with(self, other: "MatchProtocol") -> bool:
+        return other == self
+
+
+@dataclass(frozen=True)
+class MismatchProtocol(PossibleMatchProtocol):
+    pass
+
+
+@dataclass(frozen=True)
+class NoResidueDefinitions(MismatchProtocol):
     index_to_atomdef: Mapping[int, None]
     residue_definition: str
     is_match = False
@@ -51,7 +73,7 @@ class NoResidueDefinitions(MatchProtocol):
 
 
 @dataclass(frozen=True)
-class ResidueMismatch(MatchProtocol):
+class ResidueMismatch(MismatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: Mapping[int, AtomDefinition | None]
     reason: str
@@ -194,13 +216,13 @@ class ResidueMatch(MatchProtocol):
             and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
         )
 
-    def agrees_with(self, other: "Self | MoleculeMatch") -> bool:
+    def agrees_with(self, other: MatchProtocol) -> bool:
         """True if both matches would assign the same chemistry, False otherwise"""
         if set(self.index_to_atomdef.keys()) != set(other.index_to_atomdef.keys()):
             return False
 
-        if isinstance(other, MoleculeMatch):
-            return False
+        if not isinstance(other, ResidueMatch):
+            return super().agrees_with(other)
 
         name_map: dict[str, str] = {}
         for i, self_atom in self.index_to_atomdef.items():
@@ -258,38 +280,26 @@ class ResidueMatch(MatchProtocol):
         )
 
 
+@dataclass(frozen=True)
+class MoleculeMatch(MatchProtocol):
+    residue_definition: Molecule
+    index_to_atomdef: dict[int, None]
+    is_match = True
+
+    def agrees_with(self, other: MatchProtocol) -> bool:
+        return (  # no-fmt
+            other.residue_definition is self.residue_definition
+            and set(self.index_to_atomdef.keys()) == set(other.index_to_atomdef.keys())
+        )
+
+    @property
+    def match(self) -> Self:
+        return self
+
+
 @dataclass
 class PossibleResidueMatch:
-    match: ResidueMismatch | ResidueMatch | NoResidueDefinitions
-
-    @classmethod
-    def matched(
-        cls,
-        index_to_atomdef: dict[int, AtomDefinition],
-        residue_definition: ResidueDefinition,
-    ) -> Self:
-        return cls(
-            match=ResidueMatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                crosslink_idcs=None,
-            ),
-        )
-
-    @classmethod
-    def mismatched(
-        cls,
-        index_to_atomdef: dict[int, AtomDefinition | None],
-        residue_definition: ResidueDefinition,
-        reason: str,
-    ) -> Self:
-        return cls(
-            match=ResidueMismatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                reason=reason,
-            ),
-        )
+    match: MatchProtocol | MismatchProtocol
 
     def reject(self, reason: str) -> Self:
         if isinstance(self.match, ResidueMatch):
@@ -312,24 +322,7 @@ class PossibleResidueMatch:
         return bool(self.match)
 
 
-@dataclass(frozen=True)
-class MoleculeMatch(MatchProtocol):
-    residue_definition: Molecule
-    index_to_atomdef: dict[int, None]
-    is_match = True
-
-    def agrees_with(self, other: Self | ResidueMatch) -> bool:
-        return (  # no-fmt
-            other.residue_definition is self.residue_definition
-            and set(self.index_to_atomdef.keys()) == set(other.index_to_atomdef.keys())
-        )
-
-    @property
-    def match(self) -> Self:
-        return self
-
-
 def only_matched(
     iterable: Iterable[PossibleResidueMatch],
-) -> Iterable[ResidueMatch]:
-    return (p.match for p in iterable if isinstance(p.match, (ResidueMatch)))
+) -> Iterable[MatchProtocol]:
+    return (p.match for p in iterable if isinstance(p.match, MatchProtocol))

--- a/openff/pablo/_matching.py
+++ b/openff/pablo/_matching.py
@@ -1,0 +1,328 @@
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from functools import cached_property
+from typing import ClassVar, Protocol, Self
+
+from openff.toolkit import Molecule
+
+from .residue import AtomDefinition, BondDefinition, ResidueDefinition
+
+
+# TODO: Refactor
+@dataclass(frozen=True)
+class ResidueMatchProtocol(Protocol):
+    residue_definition: ResidueDefinition | str | Molecule
+    index_to_atomdef: Mapping[int, AtomDefinition | None]
+    is_match: ClassVar[bool]
+
+    @cached_property
+    def res_atom_idcs(self) -> tuple[int, ...]:
+        return tuple(sorted(self.index_to_atomdef))
+
+    def __bool__(self) -> bool:
+        return self.is_match
+
+    @property
+    def description(self) -> str:
+        if isinstance(self.residue_definition, str):
+            return self.residue_definition
+        elif isinstance(self.residue_definition, Molecule):
+            return self.residue_definition.name
+        else:
+            return self.residue_definition.description
+
+    @property
+    def prototype_index(self) -> int:
+        return next(iter(self.index_to_atomdef))
+
+
+@dataclass(frozen=True)
+class NoResidueDefinitions(ResidueMatchProtocol):
+    index_to_atomdef: Mapping[int, None]
+    residue_definition: str
+    is_match = False
+
+    @property
+    def description(self) -> str:
+        return f"No residue definitions for {self.residue_definition}@{list(self.res_atom_idcs)[:1]}"
+
+
+@dataclass(frozen=True)
+class ResidueMismatch(ResidueMatchProtocol):
+    residue_definition: ResidueDefinition
+    index_to_atomdef: Mapping[int, AtomDefinition | None]
+    reasons: list[str]
+    is_match = False
+
+    @property
+    def description(self) -> str:
+        return f"{self.residue_definition.description} failed to match because {self.reasons}"
+
+
+@dataclass(frozen=True)
+class ResidueMatch(ResidueMatchProtocol):
+    residue_definition: ResidueDefinition
+    index_to_atomdef: dict[int, AtomDefinition]
+    prior_bond_idcs: tuple[int, int] | None = None
+    posterior_bond_idcs: tuple[int, int] | None = None
+    crosslink_idcs: tuple[int, int] | None = None
+    """PDB indices of each bonded atom"""
+    is_match = True
+
+    def atom(self, identifier: int | str) -> AtomDefinition:
+        """Get an atom definition by name or PDB index"""
+        if isinstance(identifier, int):
+            return self.index_to_atomdef[identifier]
+        elif isinstance(identifier, str):
+            return self.residue_definition.name_to_atom[identifier]
+        else:
+            raise TypeError(f"unknown identifier type {type(identifier)}")
+
+    def set_crosslink(self, atom1_idx: int, atom2_idx: int) -> None:
+        """Set a match for crosslinking"""
+        if (
+            self.residue_definition.crosslink is None
+            or atom1_idx not in self.res_atom_idcs
+            or self.atom(atom1_idx).name != self.residue_definition.crosslink.atom1
+            or atom2_idx in self.res_atom_idcs
+        ):
+            raise ValueError("bad crosslink index(es)")
+        object.__setattr__(self, "crosslink_idcs", (atom1_idx, atom2_idx))
+
+    def set_prior_bond(self, d: dict[BondDefinition, int]) -> None:
+        if self.residue_definition.linking_bond is None:
+            raise ValueError("cannot set prior bond without linking_bond")
+
+        prior_bond_idcs: tuple[int, int] = (
+            d[self.residue_definition.linking_bond],
+            self.canonical_atom_name_to_index[
+                self.residue_definition.prior_bond_linking_atom
+            ],
+        )
+        object.__setattr__(
+            self,
+            "prior_bond_idcs",
+            prior_bond_idcs,
+        )
+
+    def set_posterior_bond(self, d: dict[BondDefinition, int]) -> None:
+        if self.residue_definition.linking_bond is None:
+            raise ValueError("cannot set posterior bond without linking_bond")
+
+        posterior_bond_idcs: tuple[int, int] = (
+            d[self.residue_definition.linking_bond],
+            self.canonical_atom_name_to_index[
+                self.residue_definition.posterior_bond_linking_atom
+            ],
+        )
+        object.__setattr__(
+            self,
+            "posterior_bond_idcs",
+            posterior_bond_idcs,
+        )
+
+    @cached_property
+    def missing_atoms(self) -> set[str]:
+        """Atoms present in the residue definition that were not matched"""
+        return {
+            atom.name
+            for atom in self.residue_definition.atoms
+            if atom.name not in self.canonical_atom_name_to_index
+        }
+
+    @cached_property
+    def missing_leaving_atoms(self) -> set[str]:
+        return {
+            atom_name
+            for atom_name in self.missing_atoms
+            if self.atom(atom_name).leaving
+        }
+
+    @cached_property
+    def canonical_atom_name_to_index(self) -> dict[str, int]:
+        return {atom.name: i for i, atom in self.index_to_atomdef.items()}
+
+    @cached_property
+    def expects_prior_bond(self) -> bool:
+        if self.residue_definition.linking_bond is None:
+            return False
+
+        linking_atom = self.residue_definition.prior_bond_linking_atom
+        expected_leaving_atoms = self.residue_definition.prior_bond_leaving_atoms
+
+        return (
+            linking_atom in self.canonical_atom_name_to_index
+            and len(expected_leaving_atoms) > 0
+            and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
+        )
+
+    @cached_property
+    def expects_posterior_bond(self) -> bool:
+        if self.residue_definition.linking_bond is None:
+            return False
+
+        linking_atom = self.residue_definition.posterior_bond_linking_atom
+        expected_leaving_atoms = self.residue_definition.posterior_bond_leaving_atoms
+
+        return (
+            linking_atom in self.canonical_atom_name_to_index
+            and len(expected_leaving_atoms) > 0
+            and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
+        )
+
+    @cached_property
+    def expects_crosslink(self) -> bool:
+        if self.residue_definition.crosslink is None:
+            return False
+
+        linking_atom = self.residue_definition.crosslink.atom1
+        expected_leaving_atoms = self.residue_definition.crosslink_leaving_atoms
+
+        return (
+            linking_atom in self.canonical_atom_name_to_index
+            and len(expected_leaving_atoms) > 0
+            and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
+        )
+
+    def agrees_with(self, other: "Self | MoleculeMatch") -> bool:
+        """True if both matches would assign the same chemistry, False otherwise"""
+        if set(self.index_to_atomdef.keys()) != set(other.index_to_atomdef.keys()):
+            return False
+
+        if isinstance(other, MoleculeMatch):
+            return False
+
+        name_map: dict[str, str] = {}
+        for i, self_atom in self.index_to_atomdef.items():
+            other_atom = other.index_to_atomdef[i]
+            if not (
+                self_atom.aromatic == other_atom.aromatic
+                and self_atom.charge == other_atom.charge
+                and self_atom.symbol == other_atom.symbol
+                and self_atom.stereo == other_atom.stereo
+            ):
+                return False
+            name_map[self_atom.name] = other_atom.name
+
+        self_bonds = {
+            (
+                *sorted([name_map[bond.atom1], name_map[bond.atom2]]),
+                bond.aromatic,
+                bond.order,
+                bond.stereo,
+            )
+            for bond in self.residue_definition.bonds
+            if bond.atom1 in self.canonical_atom_name_to_index
+            and bond.atom2 in self.canonical_atom_name_to_index
+        }
+        other_bonds = {
+            (
+                *sorted([bond.atom1, bond.atom2]),
+                bond.aromatic,
+                bond.order,
+                bond.stereo,
+            )
+            for bond in other.residue_definition.bonds
+            if bond.atom1 in self.canonical_atom_name_to_index
+            and bond.atom2 in self.canonical_atom_name_to_index
+        }
+        if self_bonds != other_bonds:
+            return False
+
+        if self.expects_crosslink and (
+            self.crosslink_idcs != other.crosslink_idcs
+            or self.residue_definition.crosslink != other.residue_definition.crosslink
+        ):
+            return False
+
+        if (self.expects_prior_bond or self.expects_posterior_bond) and (
+            self.residue_definition.linking_bond
+            != other.residue_definition.linking_bond
+        ):
+            return False
+
+        return (
+            self.expects_crosslink == other.expects_crosslink
+            and self.expects_prior_bond == other.expects_prior_bond
+            and self.expects_posterior_bond == other.expects_posterior_bond
+        )
+
+
+@dataclass
+class PossibleResidueMatch:
+    match: ResidueMismatch | ResidueMatch | NoResidueDefinitions
+
+    @classmethod
+    def matched(
+        cls,
+        index_to_atomdef: dict[int, AtomDefinition],
+        residue_definition: ResidueDefinition,
+    ) -> Self:
+        return cls(
+            match=ResidueMatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                crosslink_idcs=None,
+            ),
+        )
+
+    @classmethod
+    def mismatched(
+        cls,
+        index_to_atomdef: dict[int, AtomDefinition | None],
+        residue_definition: ResidueDefinition,
+        reason: str,
+    ) -> Self:
+        return cls(
+            match=ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                reasons=[reason],
+            ),
+        )
+
+    def reject(self, reason: str) -> Self:
+        if isinstance(self.match, ResidueMatch):
+            self.match = ResidueMismatch(
+                residue_definition=self.match.residue_definition,
+                index_to_atomdef=self.match.index_to_atomdef,
+                reasons=[*self._reasons(), reason],
+            )
+        return self
+
+    @property
+    def res_atom_idcs(self) -> tuple[int, ...]:
+        return self.match.res_atom_idcs
+
+    @property
+    def prototype_index(self) -> int:
+        return self.match.prototype_index
+
+    def _reasons(self) -> list[str]:
+        return self.match.reasons if isinstance(self.match, ResidueMismatch) else []
+
+    def __bool__(self) -> bool:
+        return bool(self.match)
+
+
+@dataclass(frozen=True)
+class MoleculeMatch(ResidueMatchProtocol):
+    residue_definition: Molecule
+    index_to_atomdef: dict[int, None]
+    is_match = True
+
+    def agrees_with(self, other: Self | ResidueMatch) -> bool:
+        return (  # no-fmt
+            other.residue_definition is self.residue_definition
+            and set(self.index_to_atomdef.keys()) == set(other.index_to_atomdef.keys())
+        )
+
+    @property
+    def match(self) -> Self:
+        return self
+
+
+def only_matched(
+    iterable: Iterable[PossibleResidueMatch],
+) -> Iterable[ResidueMatch]:
+    return (p.match for p in iterable if isinstance(p.match, (ResidueMatch)))

--- a/openff/pablo/_matching.py
+++ b/openff/pablo/_matching.py
@@ -10,7 +10,7 @@ from .residue import AtomDefinition, BondDefinition, ResidueDefinition
 
 # TODO: Refactor
 @dataclass(frozen=True)
-class ResidueMatchProtocol(Protocol):
+class MatchProtocol(Protocol):
     residue_definition: ResidueDefinition | str | Molecule
     index_to_atomdef: Mapping[int, AtomDefinition | None]
     is_match: ClassVar[bool]
@@ -40,7 +40,7 @@ class ResidueMatchProtocol(Protocol):
 
 
 @dataclass(frozen=True)
-class NoResidueDefinitions(ResidueMatchProtocol):
+class NoResidueDefinitions(MatchProtocol):
     index_to_atomdef: Mapping[int, None]
     residue_definition: str
     is_match = False
@@ -51,7 +51,7 @@ class NoResidueDefinitions(ResidueMatchProtocol):
 
 
 @dataclass(frozen=True)
-class ResidueMismatch(ResidueMatchProtocol):
+class ResidueMismatch(MatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: Mapping[int, AtomDefinition | None]
     reason: str
@@ -70,7 +70,7 @@ class ResidueMismatch(ResidueMatchProtocol):
 
 
 @dataclass(frozen=True)
-class ResidueMatch(ResidueMatchProtocol):
+class ResidueMatch(MatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: dict[int, AtomDefinition]
     prior_bond_idcs: tuple[int, int] | None = None
@@ -313,7 +313,7 @@ class PossibleResidueMatch:
 
 
 @dataclass(frozen=True)
-class MoleculeMatch(ResidueMatchProtocol):
+class MoleculeMatch(MatchProtocol):
     residue_definition: Molecule
     index_to_atomdef: dict[int, None]
     is_match = True

--- a/openff/pablo/_matching.py
+++ b/openff/pablo/_matching.py
@@ -32,7 +32,7 @@ class PossibleMatchProtocol(Protocol):
 
     @property
     def prototype_index(self) -> int:
-        return next(iter(self.index_to_atomdef))
+        return max(self.index_to_atomdef)
 
     def sort_key(self) -> tuple[str, ...]:
         return (self.description,)

--- a/openff/pablo/_matching.py
+++ b/openff/pablo/_matching.py
@@ -35,6 +35,9 @@ class ResidueMatchProtocol(Protocol):
     def prototype_index(self) -> int:
         return next(iter(self.index_to_atomdef))
 
+    def sort_key(self) -> tuple[str, ...]:
+        return (self.description,)
+
 
 @dataclass(frozen=True)
 class NoResidueDefinitions(ResidueMatchProtocol):
@@ -51,12 +54,19 @@ class NoResidueDefinitions(ResidueMatchProtocol):
 class ResidueMismatch(ResidueMatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: Mapping[int, AtomDefinition | None]
-    reasons: list[str]
+    reason: str
     is_match = False
 
     @property
     def description(self) -> str:
-        return f"{self.residue_definition.description} failed to match because {self.reasons}"
+        return f"{self.residue_definition.description} failed to match: {self.reason}"
+
+    def sort_key(self) -> tuple[str, ...]:
+        return (
+            self.reason,
+            f"{len(self.residue_definition.description):0>10}",
+            self.residue_definition.description,
+        )
 
 
 @dataclass(frozen=True)
@@ -277,7 +287,7 @@ class PossibleResidueMatch:
             match=ResidueMismatch(
                 residue_definition=residue_definition,
                 index_to_atomdef=index_to_atomdef,
-                reasons=[reason],
+                reason=reason,
             ),
         )
 
@@ -286,7 +296,7 @@ class PossibleResidueMatch:
             self.match = ResidueMismatch(
                 residue_definition=self.match.residue_definition,
                 index_to_atomdef=self.match.index_to_atomdef,
-                reasons=[*self._reasons(), reason],
+                reason=reason,
             )
         return self
 
@@ -297,9 +307,6 @@ class PossibleResidueMatch:
     @property
     def prototype_index(self) -> int:
         return self.match.prototype_index
-
-    def _reasons(self) -> list[str]:
-        return self.match.reasons if isinstance(self.match, ResidueMismatch) else []
 
     def __bool__(self) -> bool:
         return bool(self.match)

--- a/openff/pablo/_matching.py
+++ b/openff/pablo/_matching.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from functools import cached_property
-from typing import ClassVar, Protocol, Self
+from typing import ClassVar, Protocol, Self, TypeAlias
 
 from openff.toolkit import Molecule
 
@@ -100,6 +100,13 @@ class ResidueMatch(MatchProtocol):
     crosslink_idcs: tuple[int, int] | None = None
     """PDB indices of each bonded atom"""
     is_match = True
+
+    def reject(self, reason: str) -> ResidueMismatch:
+        return ResidueMismatch(
+            residue_definition=self.residue_definition,
+            index_to_atomdef=self.index_to_atomdef,
+            reason=reason,
+        )
 
     def atom(self, identifier: int | str) -> AtomDefinition:
         """Get an atom definition by name or PDB index"""
@@ -297,32 +304,11 @@ class MoleculeMatch(MatchProtocol):
         return self
 
 
-@dataclass
-class PossibleResidueMatch:
-    match: MatchProtocol | MismatchProtocol
-
-    def reject(self, reason: str) -> Self:
-        if isinstance(self.match, ResidueMatch):
-            self.match = ResidueMismatch(
-                residue_definition=self.match.residue_definition,
-                index_to_atomdef=self.match.index_to_atomdef,
-                reason=reason,
-            )
-        return self
-
-    @property
-    def res_atom_idcs(self) -> tuple[int, ...]:
-        return self.match.res_atom_idcs
-
-    @property
-    def prototype_index(self) -> int:
-        return self.match.prototype_index
-
-    def __bool__(self) -> bool:
-        return bool(self.match)
+SuccessfulMatch: TypeAlias = ResidueMatch | MoleculeMatch
+PossibleResidueMatch: TypeAlias = SuccessfulMatch | MismatchProtocol
 
 
 def only_matched(
     iterable: Iterable[PossibleResidueMatch],
 ) -> Iterable[MatchProtocol]:
-    return (p.match for p in iterable if isinstance(p.match, MatchProtocol))
+    return (p for p in iterable if isinstance(p, MatchProtocol))

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -170,32 +170,12 @@ def topology_from_pdb(
 
     this_molecule = Molecule()
     molecules: list[Molecule] = [this_molecule]
-    prev_chain_id = data.chain_id[0]
-    prev_model = data.model[0]
     chemical_data: MoleculeMatch | ResidueMatch
-    for res_atom_idcs, chemical_data in zip(
-        data.residue_indices,
-        data.get_residue_matches(
-            residue_database,
-            additional_substructures,
-            unknown_molecules,
-        ),
+    for chemical_data in data.get_residue_matches(
+        residue_database,
+        additional_substructures,
+        unknown_molecules,
     ):
-        prototype_index = res_atom_idcs[0]
-
-        # Terminate the previous molecule and start a new one if we can see that
-        # this is the start of a new molecule
-        if this_molecule.n_atoms > 0 and (
-            data.chain_id[prototype_index] != prev_chain_id
-            or data.model[prototype_index] != prev_model
-            or (
-                isinstance(chemical_data, ResidueMatch)
-                and not chemical_data.expects_prior_bond
-            )
-        ):
-            this_molecule = Molecule()
-            molecules.append(this_molecule)
-
         # Apply the chemical data we've collected
         if isinstance(chemical_data, MoleculeMatch):
             this_molecule = chemical_data.residue_definition
@@ -214,14 +194,10 @@ def topology_from_pdb(
         else:
             assert_never(chemical_data)
 
-        # Terminate the current molecule if we can see that this is the last residue
-        if (
-            data.terminated[prototype_index]
-            or isinstance(chemical_data, MoleculeMatch)
-            or (
-                isinstance(chemical_data, ResidueMatch)
-                and not chemical_data.expects_posterior_bond
-            )
+        # Terminate the current molecule if this residue has no posterior bond
+        if isinstance(chemical_data, MoleculeMatch) or (
+            isinstance(chemical_data, ResidueMatch)
+            and chemical_data.posterior_bond_idcs is None
         ):
             this_molecule = Molecule()
             molecules.append(this_molecule)
@@ -229,9 +205,6 @@ def topology_from_pdb(
         # TODO: Load other data from PDB file
         # TODO: Incorporate CONECT records
         # TODO: Deal with multi-model files
-
-        prev_chain_id = data.chain_id[prototype_index]
-        prev_model = data.model[prototype_index]
 
     for offmol in molecules:
         offmol._invalidate_cached_properties()

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -1,4 +1,4 @@
-import itertools
+import logging
 import warnings
 from collections.abc import Iterable, Mapping, MutableSequence
 from io import TextIOBase
@@ -9,6 +9,8 @@ import numpy as np
 from openff.toolkit import Molecule, Topology
 from openff.units import elements, unit
 
+from openff.pablo._matching import MoleculeMatch
+
 from ._pdb_data import PdbData, ResidueMatch
 from ._utils import (
     assign_stereochemistry_from_3d,
@@ -16,10 +18,6 @@ from ._utils import (
     sort_tuple,
 )
 from .ccd import CCD_RESIDUE_DEFINITION_CACHE
-from .exceptions import (
-    MultipleMatchingResidueDefinitionsError,
-    NoMatchingResidueDefinitionError,
-)
 from .residue import ResidueDefinition
 
 __all__ = [
@@ -126,9 +124,13 @@ def topology_from_pdb(
     ``"residue_name"``
         The residue name
     ``"residue_number"``
-        The residue number as the string found in the PDB file
+        The residue number, converted to an ``int``. If the residue number
+        cannot be converted to an ``int``, the residue index instead.
     ``"res_seq"``
-        The residue number, converted to an ``int`` on a best-effort basis.
+        The residue number as the string found in the PDB file
+    ``"residue_index"``
+        The residue index; the first residue has index ``0``, the second ``1``,
+        etc., regardless of the value of the res_seq column.
     ``"insertion_code"``
         The icode for the atom's residue. Used to align residue numbers between
         proteins with indels.
@@ -170,45 +172,15 @@ def topology_from_pdb(
     molecules: list[Molecule] = [this_molecule]
     prev_chain_id = data.chain_id[0]
     prev_model = data.model[0]
-    for res_atom_idcs, matches in zip(
+    chemical_data: MoleculeMatch | ResidueMatch
+    for res_atom_idcs, chemical_data in zip(
         data.residue_indices,
-        data.get_residue_matches(residue_database, additional_substructures),
+        data.get_residue_matches(
+            residue_database,
+            additional_substructures,
+            unknown_molecules,
+        ),
     ):
-        # Check that we have a unique match, and error out or consult
-        # unique_molecules as appropriate
-        chemical_data: Molecule | ResidueMatch
-        if len(matches) == 0:
-            unknown_molecule = _match_unknown_molecules(
-                data,
-                res_atom_idcs,
-                unknown_molecules,
-            )
-            if unknown_molecule is None:
-                raise NoMatchingResidueDefinitionError(
-                    res_atom_idcs,
-                    data,
-                    unknown_molecules,
-                    additional_substructures,
-                    residue_database,
-                    verbose_errors=verbose_errors,
-                )
-            else:
-                chemical_data = unknown_molecule
-        # If all matches would assign the same chemistry, accept it
-        # assert all([]) == True
-        elif all(a.agrees_with(b) for a, b in itertools.pairwise(matches)):
-            chemical_data = matches[0]
-
-            # this is a debug assert, if it triggers there's a bug
-            assert set(res_atom_idcs) == chemical_data.res_atom_idcs
-        else:
-            raise MultipleMatchingResidueDefinitionsError(
-                matches,
-                res_atom_idcs,
-                data,
-                verbose_errors=verbose_errors,
-            )
-
         prototype_index = res_atom_idcs[0]
 
         # Terminate the previous molecule and start a new one if we can see that
@@ -225,8 +197,8 @@ def topology_from_pdb(
             molecules.append(this_molecule)
 
         # Apply the chemical data we've collected
-        if isinstance(chemical_data, Molecule):
-            this_molecule = chemical_data
+        if isinstance(chemical_data, MoleculeMatch):
+            this_molecule = chemical_data.residue_definition
             if molecules[-1].n_atoms == 0:
                 molecules[-1] = this_molecule
             else:
@@ -245,7 +217,7 @@ def topology_from_pdb(
         # Terminate the current molecule if we can see that this is the last residue
         if (
             data.terminated[prototype_index]
-            or isinstance(chemical_data, Molecule)
+            or isinstance(chemical_data, MoleculeMatch)
             or (
                 isinstance(chemical_data, ResidueMatch)
                 and not chemical_data.expects_posterior_bond
@@ -272,6 +244,13 @@ def topology_from_pdb(
     positions = np.stack([data.x[:n], data.y[:n], data.z[:n]], axis=-1) * unit.angstrom
     topology.set_positions(positions[topology_pdb_indices])
     if topology_pdb_indices != list(range(n)):
+        logging.debug(
+            "\n".join(
+                f"topology index {j: <n} has pdb index {i: <n}"
+                for i, j in zip(topology_pdb_indices, range(n))
+                if i != j
+            ),
+        )
         warnings.warn(
             "Input PDB has an atom ordering that cannot be represented in an"
             + " OpenFF Topology. The atoms in this topology will not be in same"
@@ -332,71 +311,6 @@ def _set_box_vectors(topology: Topology, data: PdbData):
             data.cryst1_beta,
             data.cryst1_gamma,
         )
-
-
-def _match_unknown_molecules(
-    data: PdbData,
-    indices: tuple[int, ...],
-    unknown_molecules: Iterable[Molecule],
-) -> Molecule | None:
-    conects: set[tuple[int, int]] = set()
-    pdb_idx_to_mol_idx: dict[int, int] = {}
-    pdbmol = Molecule()
-    for pdb_index in indices:
-        pdb_idx_to_mol_idx[pdb_index] = pdbmol.add_atom(
-            atomic_number=elements.NUMBERS[data.element[pdb_index]],
-            formal_charge=data.charge[pdb_index] or 0,
-            is_aromatic=False,
-            stereochemistry=None,
-            name=data.name[pdb_index],
-            metadata={
-                "leaving": False,
-                **data._generate_atom_metadata(pdb_index),
-            },
-        )
-        for conect_idx in data.conects[pdb_index]:
-            conects.add(sort_tuple((pdb_index, conect_idx)))
-
-    for a, b in conects:
-        try:
-            pdbmol.add_bond(
-                atom1=pdb_idx_to_mol_idx[a],
-                atom2=pdb_idx_to_mol_idx[b],
-                bond_order=1,
-                is_aromatic=False,
-            )
-        except KeyError:
-            a_summary = f"{data.name[a]}#{data.serial[a]}@{data.chain_id[a]}:{data.res_name[a]}#{data.res_seq[a]}"
-            b_summary = f"{data.name[b]}#{data.serial[b]}@{data.chain_id[b]}:{data.res_name[b]}#{data.res_seq[b]}"
-            raise ValueError(
-                "Cannot match unknown molecule that spans multiple residues: "
-                + f"Found CONECT record between {a_summary} and {b_summary}",
-            )
-
-    for molecule in unknown_molecules:
-        (match_found, mapping) = Molecule.are_isomorphic(
-            molecule,
-            pdbmol,
-            return_atom_map=True,
-            aromatic_matching=False,
-            formal_charge_matching=False,
-            bond_order_matching=False,
-            atom_stereochemistry_matching=False,
-            bond_stereochemistry_matching=False,
-            strip_pyrimidal_n_atom_stereo=True,
-        )
-        if match_found:
-            assert mapping is not None
-            molecule = molecule.remap(mapping)
-            for atom, pdbatom in zip(molecule.atoms, pdbmol.atoms):
-                atom.metadata.update(pdbatom.metadata)
-                atom.name = pdbatom.name
-            molecule.generate_conformers(n_conformers=0, clear_existing=True)
-            molecule.properties["pdb_idx_to_mol_atom_idx"] = pdb_idx_to_mol_idx
-
-            return molecule
-    else:
-        return None
 
 
 def _add_to_molecule(

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -3,7 +3,7 @@ import warnings
 from collections.abc import Iterable, Mapping, MutableSequence
 from io import TextIOBase
 from os import PathLike
-from typing import IO, assert_never
+from typing import IO
 
 import numpy as np
 from openff.toolkit import Molecule, Topology
@@ -170,7 +170,6 @@ def topology_from_pdb(
 
     this_molecule = Molecule()
     molecules: list[Molecule] = [this_molecule]
-    chemical_data: MoleculeMatch | ResidueMatch
     for chemical_data in data.get_residue_matches(
         residue_database,
         additional_substructures,
@@ -192,7 +191,7 @@ def topology_from_pdb(
                 use_canonical_names,
             )
         else:
-            assert_never(chemical_data)
+            raise TypeError("unknown match type. This is a bug, please report it")
 
         # Terminate the current molecule if this residue has no posterior bond
         if isinstance(chemical_data, MoleculeMatch) or (

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -3,7 +3,7 @@ import warnings
 from collections.abc import Iterable, Mapping, MutableSequence
 from io import TextIOBase
 from os import PathLike
-from typing import IO
+from typing import IO, assert_never
 
 import numpy as np
 from openff.toolkit import Molecule, Topology
@@ -191,7 +191,7 @@ def topology_from_pdb(
                 use_canonical_names,
             )
         else:
-            raise TypeError("unknown match type. This is a bug, please report it")
+            assert_never(chemical_data)
 
         # Terminate the current molecule if this residue has no posterior bond
         if isinstance(chemical_data, MoleculeMatch) or (

--- a/openff/pablo/_pdb.py
+++ b/openff/pablo/_pdb.py
@@ -218,7 +218,7 @@ def topology_from_pdb(
             or data.model[prototype_index] != prev_model
             or (
                 isinstance(chemical_data, ResidueMatch)
-                and not chemical_data.expect_prior_bond
+                and not chemical_data.expects_prior_bond
             )
         ):
             this_molecule = Molecule()
@@ -248,7 +248,7 @@ def topology_from_pdb(
             or isinstance(chemical_data, Molecule)
             or (
                 isinstance(chemical_data, ResidueMatch)
-                and not chemical_data.expect_posterior_bond
+                and not chemical_data.expects_posterior_bond
             )
         ):
             this_molecule = Molecule()
@@ -408,7 +408,7 @@ def _add_to_molecule(
 ) -> Molecule:
     # Identify the previous linking atom
     linking_atom_idx: None | int = None
-    if residue_match.expect_prior_bond:
+    if residue_match.expects_prior_bond:
         assert residue_match.residue_definition.linking_bond is not None
         linking_atom_name = residue_match.residue_definition.linking_bond.atom1
         for i in reversed(range(this_molecule.n_atoms)):
@@ -470,8 +470,8 @@ def _add_to_molecule(
             invalidate_cache=False,
         )
 
-    if residue_match.crosslink is not None:
-        this_idx, other_idx = residue_match.crosslink
+    if residue_match.crosslink_idcs is not None:
+        this_idx, other_idx = residue_match.crosslink_idcs
         crosslink_bond = residue_match.residue_definition.crosslink
         assert crosslink_bond is not None, "Crosslink cannot be None if in match"
         if other_idx > this_idx:

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -7,13 +7,21 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from io import TextIOBase
 from os import PathLike
-from typing import IO, Any, DefaultDict, Protocol, Self
+from typing import IO, Any, ClassVar, DefaultDict, Protocol, Self
+from collections.abc import Collection
 
-from ._utils import __UNSET__, charge_int_or_none, dec_hex, with_neighbours
+from ._utils import (
+    __UNSET__,
+    charge_int_or_none,
+    dec_hex,
+    flatten,
+    sort_tuple,
+    with_neighbours,
+)
 from .exceptions import (
     UnknownOrAmbiguousSerialInConectError,
 )
-from .residue import AtomDefinition, ResidueDefinition
+from .residue import AtomDefinition, BondDefinition, ResidueDefinition
 
 __all__ = [
     "ResidueMatch",
@@ -21,35 +29,60 @@ __all__ = [
 ]
 
 
+# TODO: Refactor
 @dataclass(frozen=True)
 class ResidueMatchProtocol(Protocol):
-    residue_definition: ResidueDefinition
+    residue_definition: ResidueDefinition | str
     index_to_atomdef: Mapping[int, AtomDefinition | None]
+    is_match: ClassVar[bool]
 
     @cached_property
     def res_atom_idcs(self) -> set[int]:
         return set(self.index_to_atomdef)
+
+    def __bool__(self) -> bool:
+        return self.is_match
+
+    @property
+    def description(self) -> str:
+        if isinstance(self.residue_definition, str):
+            return self.residue_definition
+        else:
+            return self.residue_definition.description
+
+
+@dataclass(frozen=True)
+class NoResidueDefinitions(ResidueMatchProtocol):
+    index_to_atomdef: Mapping[int, None]
+    residue_definition: str
+    is_match = False
+
+    @property
+    def description(self) -> str:
+        return f"No residue definitions for {self.residue_definition}@{list(self.res_atom_idcs)[:1]}"
 
 
 @dataclass(frozen=True)
 class ResidueMismatch(ResidueMatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: Mapping[int, AtomDefinition | None]
-    reason: str
+    reasons: list[str]
+    is_match = False
 
-    def __bool__(self) -> bool:
-        return False
+    @property
+    def description(self) -> str:
+        return f"{self.residue_definition.description} failed to match because {self.reasons}"
 
 
 @dataclass(frozen=True)
 class ResidueMatch(ResidueMatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: dict[int, AtomDefinition]
-    crosslink: tuple[int, int] | None = None
+    prior_bond_idcs: tuple[int, int] | None = None
+    posterior_bond_idcs: tuple[int, int] | None = None
+    crosslink_idcs: tuple[int, int] | None = None
     """PDB indices of each bonded atom"""
-
-    def __bool__(self) -> bool:
-        return True
+    is_match = True
 
     def atom(self, identifier: int | str) -> AtomDefinition:
         """Get an atom definition by name or PDB index"""
@@ -69,7 +102,39 @@ class ResidueMatch(ResidueMatchProtocol):
             or atom2_idx in self.res_atom_idcs
         ):
             raise ValueError("bad crosslink index(es)")
-        object.__setattr__(self, "crosslink", (atom1_idx, atom2_idx))
+        object.__setattr__(self, "crosslink_idcs", (atom1_idx, atom2_idx))
+
+    def set_prior_bond(self, d: dict[BondDefinition, int]) -> None:
+        if self.residue_definition.linking_bond is None:
+            raise ValueError("cannot set prior bond without linking_bond")
+
+        prior_bond_idcs: tuple[int, int] = (
+            d[self.residue_definition.linking_bond],
+            self.canonical_atom_name_to_index[
+                self.residue_definition.prior_bond_linking_atom
+            ],
+        )
+        object.__setattr__(
+            self,
+            "prior_bond_idcs",
+            prior_bond_idcs,
+        )
+
+    def set_posterior_bond(self, d: dict[BondDefinition, int]) -> None:
+        if self.residue_definition.linking_bond is None:
+            raise ValueError("cannot set posterior bond without linking_bond")
+
+        posterior_bond_idcs: tuple[int, int] = (
+            d[self.residue_definition.linking_bond],
+            self.canonical_atom_name_to_index[
+                self.residue_definition.posterior_bond_linking_atom
+            ],
+        )
+        object.__setattr__(
+            self,
+            "posterior_bond_idcs",
+            posterior_bond_idcs,
+        )
 
     @cached_property
     def prototype_index(self) -> int:
@@ -97,7 +162,7 @@ class ResidueMatch(ResidueMatchProtocol):
         return {atom.name: i for i, atom in self.index_to_atomdef.items()}
 
     @cached_property
-    def expect_prior_bond(self) -> bool:
+    def expects_prior_bond(self) -> bool:
         if self.residue_definition.linking_bond is None:
             return False
 
@@ -111,7 +176,7 @@ class ResidueMatch(ResidueMatchProtocol):
         )
 
     @cached_property
-    def expect_posterior_bond(self) -> bool:
+    def expects_posterior_bond(self) -> bool:
         if self.residue_definition.linking_bond is None:
             return False
 
@@ -125,7 +190,7 @@ class ResidueMatch(ResidueMatchProtocol):
         )
 
     @cached_property
-    def expect_crosslink(self) -> bool:
+    def expects_crosslink(self) -> bool:
         if self.residue_definition.crosslink is None:
             return False
 
@@ -180,23 +245,84 @@ class ResidueMatch(ResidueMatchProtocol):
         if self_bonds != other_bonds:
             return False
 
-        if self.expect_crosslink and (
-            self.crosslink != other.crosslink
+        if self.expects_crosslink and (
+            self.crosslink_idcs != other.crosslink_idcs
             or self.residue_definition.crosslink != other.residue_definition.crosslink
         ):
             return False
 
-        if (self.expect_prior_bond or self.expect_posterior_bond) and (
+        if (self.expects_prior_bond or self.expects_posterior_bond) and (
             self.residue_definition.linking_bond
             != other.residue_definition.linking_bond
         ):
             return False
 
         return (
-            self.expect_crosslink == other.expect_crosslink
-            and self.expect_prior_bond == other.expect_prior_bond
-            and self.expect_posterior_bond == other.expect_posterior_bond
+            self.expects_crosslink == other.expects_crosslink
+            and self.expects_prior_bond == other.expects_prior_bond
+            and self.expects_posterior_bond == other.expects_posterior_bond
         )
+
+
+@dataclass
+class PossibleResidueMatch:
+    match: ResidueMismatch | ResidueMatch | NoResidueDefinitions
+
+    @classmethod
+    def matched(
+        cls,
+        index_to_atomdef: dict[int, AtomDefinition],
+        residue_definition: ResidueDefinition,
+    ) -> Self:
+        return cls(
+            match=ResidueMatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                crosslink_idcs=None,
+            ),
+        )
+
+    @classmethod
+    def mismatched(
+        cls,
+        index_to_atomdef: dict[int, AtomDefinition | None],
+        residue_definition: ResidueDefinition,
+        reason: str,
+    ) -> Self:
+        return cls(
+            match=ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                reasons=[reason],
+            ),
+        )
+
+    def reject(self, reason: str) -> Self:
+        if isinstance(self.match, ResidueMatch):
+            self.match = ResidueMismatch(
+                residue_definition=self.match.residue_definition,
+                index_to_atomdef=self.match.index_to_atomdef,
+                reasons=[*self._reasons(), reason],
+            )
+        return self
+
+    @property
+    def res_atom_idcs(self) -> set[int]:
+        return self.match.res_atom_idcs
+
+    @property
+    def prototype_index(self) -> int:
+        return next(iter(self.match.index_to_atomdef))
+
+    def _reasons(self) -> list[str]:
+        return self.match.reasons if isinstance(self.match, ResidueMismatch) else []
+
+    def __bool__(self) -> bool:
+        return bool(self.match)
+
+
+def only_matched(iterable: Iterable[PossibleResidueMatch]) -> Iterable[ResidueMatch]:
+    return (p.match for p in iterable if isinstance(p.match, ResidueMatch))
 
 
 @dataclass
@@ -410,9 +536,9 @@ class PdbData:
 
     def subset_matches_residue(
         self,
-        res_atom_idcs: Sequence[int],
+        res_atom_idcs: Collection[int],
         residue_definition: ResidueDefinition,
-    ) -> ResidueMismatch | ResidueMatch:
+    ) -> PossibleResidueMatch:
         # Raise an error if the match would be empty - this way the
         # return value's truthiness always reflects whether there was a match
         if len(res_atom_idcs) == 0:
@@ -424,7 +550,7 @@ class PdbData:
         if len(residue_definition.atoms) < len(res_atom_idcs):
             reason = f"Too few atoms in residue definition ({len(residue_definition.atoms)} < {len(res_atom_idcs)})"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
+            return PossibleResidueMatch.mismatched(
                 residue_definition=residue_definition,
                 index_to_atomdef={i: None for i in res_atom_idcs},
                 reason=reason,
@@ -441,7 +567,7 @@ class PdbData:
         ):
             reason = "No links and wrong number of atoms"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
+            return PossibleResidueMatch.mismatched(
                 residue_definition=residue_definition,
                 index_to_atomdef={i: None for i in res_atom_idcs},
                 reason=reason,
@@ -455,11 +581,16 @@ class PdbData:
         except KeyError:
             reason = "Name missing from residue definition"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
+            return PossibleResidueMatch.mismatched(
                 residue_definition=residue_definition,
                 index_to_atomdef={i: None for i in res_atom_idcs},
                 reason=reason,
             )
+
+        match = PossibleResidueMatch.matched(
+            index_to_atomdef=index_to_atomdef,
+            residue_definition=residue_definition,
+        )
 
         matched_atoms = {atom.name for atom in index_to_atomdef.values()}
 
@@ -467,11 +598,7 @@ class PdbData:
         if len(matched_atoms) != len(res_atom_idcs):
             reason = "Atom definition matched multiple PDB coordinate records"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                reason=reason,
-            )
+            return match.reject(reason)
 
         # This assert should be guaranteed by the above
         assert set(index_to_atomdef.keys()) == set(res_atom_idcs)
@@ -483,11 +610,7 @@ class PdbData:
         ):
             reason = "Element mismatch"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                reason=reason,
-            )
+            return match.reject(reason)
 
         # PDB files can not be trusted; ignore charges.
         # # Check that charges match, but tolerate missing columns
@@ -508,11 +631,7 @@ class PdbData:
         if any(not atom.leaving for atom in missing_atoms):
             reason = "Missing atom is not leaving atom"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                reason=reason,
-            )
+            return match.reject(reason)
         elif (
             (
                 missing_atom_names.issuperset(
@@ -540,28 +659,36 @@ class PdbData:
             )
         ):
             logging.debug("    Match succeeded!")
-            return ResidueMatch(
-                index_to_atomdef=index_to_atomdef,
-                residue_definition=residue_definition,
-            )
+            return match
         else:
             reason = "Missing atoms do not specify link"
             logging.debug("    Match failed: " + reason)
-            return ResidueMismatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                reason=reason,
-            )
+            return match.reject(reason)
 
     def get_residue_matches(
         self,
         residue_database: Mapping[str, Iterable[ResidueDefinition]],
         additional_substructures: Iterable[ResidueDefinition],
     ) -> Iterator[list[ResidueMatch]]:
-        # Identify possible matches based on atom and residue names
-        name_matches: list[list[ResidueMatch]] = []
-        atom_idx_to_res_idx: dict[int, int] = {}
-        for res_idx, res_atom_idcs in enumerate(self.residue_indices):
+        possible_matches = self.match_residues(
+            residue_database,
+            additional_substructures,
+        )
+        return (list(only_matched(matches)) for matches in possible_matches)
+
+    @cached_property
+    def atom_idx_to_res_idx(self) -> dict[int, int]:
+        value: dict[int, int] = {}
+        for res_idx, atom_indices in enumerate(self.residue_indices):
+            for atom_idx in atom_indices:
+                value[atom_idx] = res_idx
+        return value
+
+    def get_name_based_matches(
+        self,
+        residue_database: Mapping[str, Iterable[ResidueDefinition]],
+    ) -> Iterator[list[PossibleResidueMatch]]:
+        for res_atom_idcs in self.residue_indices:
             prototype_index = res_atom_idcs[0]
             res_name = self.res_name[prototype_index]
             logging.debug(f"Beginning name-based match of {res_name} {res_atom_idcs}")
@@ -570,150 +697,376 @@ class PdbData:
                     f"  Atom names are ({', '.join(self.name[i] for i in res_atom_idcs)})",
                 )
 
-            atom_idx_to_res_idx.update({i: res_idx for i in res_atom_idcs})
-
-            residue_matches: list[ResidueMatch] = []
-            for residue_definition in residue_database.get(res_name, []):
-                match = self.subset_matches_residue(
+            matches = [
+                self.subset_matches_residue(
                     res_atom_idcs,
                     residue_definition,
                 )
+                for residue_definition in residue_database.get(res_name, [])
+            ]
+            if len(matches) > 0:
+                yield matches
+            else:
+                yield [
+                    PossibleResidueMatch(
+                        match=NoResidueDefinitions(
+                            residue_definition=res_name,
+                            index_to_atomdef={i: None for i in res_atom_idcs},
+                        ),
+                    ),
+                ]
 
-                if isinstance(match, ResidueMatch):
-                    residue_matches.append(match)
-
-            if len(residue_matches) == 0:
-                for residue_definition in additional_substructures:
-                    match = self.subset_matches_residue(
-                        res_atom_idcs,
-                        residue_definition,
-                    )
-                    if isinstance(match, ResidueMatch):
-                        residue_matches.append(match)
-
-            name_matches.append(residue_matches)
-
-        # Check for polymer bonds
-        prev_filtered_matches: list[ResidueMatch] = []
-        linkage_matches: list[list[ResidueMatch]] = []
-        for _, this_matches, next_matches in with_neighbours(
-            name_matches,
+    def filter_on_polymer_linkages(
+        self,
+        matches: Sequence[Sequence[PossibleResidueMatch]],
+    ) -> None:
+        for prev_matches, this_matches, next_matches in with_neighbours(
+            matches,
             default=(),
         ):
-            if len(this_matches) != 0:
+            if len(list(only_matched(this_matches))) != 0:
                 logging.debug(
                     f"Beginning link-based match of {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
                 )
-            neighbours_support_posterior_bond = any(
-                next_match.expect_prior_bond for next_match in next_matches
-            )
-            neighbours_support_prior_bond = any(
-                prev_match.expect_posterior_bond for prev_match in prev_filtered_matches
-            )
+            # neighbour_supported_posterior_bonds and
+            # neighbour_supported_prior_bonds are maps from possible linking
+            # bonds in this residue to the atom index (in the neighbouring
+            # residue) where the linking atom can be found
+            neighbour_supported_posterior_bonds: dict[BondDefinition, int] = {
+                next_match.residue_definition.linking_bond: next_match.canonical_atom_name_to_index[
+                    next_match.residue_definition.prior_bond_linking_atom
+                ]
+                for next_match in only_matched(next_matches)
+                if next_match.residue_definition.linking_bond is not None
+                and next_match.expects_prior_bond
+            }
+            neighbour_supported_prior_bonds: dict[BondDefinition, int] = {
+                prev_match.residue_definition.linking_bond: prev_match.canonical_atom_name_to_index[
+                    prev_match.residue_definition.posterior_bond_linking_atom
+                ]
+                for prev_match in only_matched(prev_matches)
+                if prev_match.residue_definition.linking_bond is not None
+                and prev_match.expects_posterior_bond
+            }
+
+            valid_next_matches = list(only_matched(next_matches))
             neighbours_support_molecule_end = (
-                any(not next_match.expect_prior_bond for next_match in next_matches)
-                or len(next_matches) == 0
+                any(
+                    not next_match.expects_prior_bond
+                    for next_match in valid_next_matches
+                )
+                or len(valid_next_matches) == 0
             )
+            valid_prev_matches = list(only_matched(prev_matches))
             neighbours_support_molecule_start = (
                 any(
-                    not prev_match.expect_posterior_bond
-                    for prev_match in prev_filtered_matches
+                    not prev_match.expects_posterior_bond
+                    for prev_match in valid_prev_matches
                 )
-                or len(prev_filtered_matches) == 0
+                or len(valid_prev_matches) == 0
             )
-            this_filtered_matches: list[ResidueMatch] = []
-            for match in this_matches:
+            if len(list(only_matched(this_matches))) != 0:
                 logging.debug(
-                    f"  Attempting link-based match against {match.residue_definition.description}",
+                    f"  {neighbour_supported_posterior_bonds=}",
                 )
-                if len(match.missing_atoms) != 0:
-                    prior_bond_mismatched = (
-                        match.expect_prior_bond != neighbours_support_prior_bond
-                    )
-                    if prior_bond_mismatched:
-                        logging.debug("    Match failed: Prior bond mismatched")
-                        logging.debug(
-                            f"    {match.expect_prior_bond=} but {neighbours_support_prior_bond=}",
-                        )
+                logging.debug(
+                    f"  {neighbour_supported_prior_bonds=}",
+                )
+                logging.debug(
+                    f"  {neighbours_support_molecule_end=}",
+                )
+                logging.debug(
+                    f"  {neighbours_support_molecule_start=}",
+                )
+            for match in this_matches:
+                if not isinstance(match.match, ResidueMatch):
+                    continue
+                logging.debug(
+                    f"  Attempting link-based match against {match.match.residue_definition.description}",
+                )
+                if match.match.expects_prior_bond:
+                    if (
+                        match.match.residue_definition.linking_bond
+                        not in neighbour_supported_prior_bonds
+                    ):
+                        reason = "Prior bond expected but not supported by neighbours"
+                        logging.debug(f"    Match failed: {reason}")
+                        match.reject(reason)
                         continue
+                    else:
+                        match.match.set_prior_bond(neighbour_supported_prior_bonds)
+                elif not neighbours_support_molecule_start:
+                    reason = "Prior bond not permitted but required by neighbours"
+                    logging.debug(f"    Match failed: {reason}")
+                    match.reject(reason)
+                    continue
 
-                    posterior_bond_mismatched = (
-                        match.expect_posterior_bond != neighbours_support_posterior_bond
-                    )
-                    if posterior_bond_mismatched:
-                        logging.debug("    Match failed: Posterior bond mismatched")
-                        logging.debug(
-                            f"    {match.expect_posterior_bond=} but {neighbours_support_posterior_bond=}",
+                if match.match.expects_posterior_bond:
+                    if (
+                        match.match.residue_definition.linking_bond
+                        not in neighbour_supported_posterior_bonds
+                    ):
+                        reason = (
+                            "Posterior bond expected but not supported by neighbours"
                         )
+                        logging.debug(f"    Match failed: {reason}")
+                        match.reject(reason)
                         continue
+                    else:
+                        match.match.set_posterior_bond(
+                            neighbour_supported_posterior_bonds,
+                        )
+                elif not neighbours_support_molecule_end:
+                    reason = "Posterior bond not expected but required by neighbours"
+                    logging.debug(f"    Match failed: {reason}")
+                    match.reject(reason)
+                    continue
 
-                    this_filtered_matches.append(match)
-                    logging.debug("    Accepted")
-                elif (
-                    neighbours_support_molecule_end
-                    and neighbours_support_molecule_start
-                ):
-                    this_filtered_matches.append(match)
-                    logging.debug("    Accepted as non-polymer")
+                logging.debug("    Accepted")
 
-            linkage_matches.append(this_filtered_matches)
-            prev_filtered_matches = this_filtered_matches
-
+    def filter_on_crosslinks(
+        self,
+        matches: Sequence[Sequence[PossibleResidueMatch]],
+    ) -> None:
         # Check for crosslinks
         # TODO: This could be simplified if we required crosslinking atoms not to have synonyms
-        for residue_matches in linkage_matches:
+        for residue_matches in matches:
+            if len(list(only_matched(residue_matches))) != 0:
+                logging.debug(
+                    f"Assigning crosslinks for {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+                )
             for match in residue_matches:
-                if match.crosslink is not None:
+                if not isinstance(match.match, ResidueMatch):
+                    continue
+                logging.debug(
+                    f"  Attempting crosslink-based match against {match.match.residue_definition.description}",
+                )
+                if match.match.crosslink_idcs is not None:
                     # This match's crosslink has already been assigned
+                    logging.debug(
+                        "    Skipping (crosslink already assigned)",
+                    )
                     continue
-                if not match.expect_crosslink:
+                if not match.match.expects_crosslink:
+                    logging.debug(
+                        "    Skipping (crosslink not expected)",
+                    )
                     continue
-                this_crosslink_def = match.residue_definition.crosslink
+                this_crosslink_def = match.match.residue_definition.crosslink
                 if this_crosslink_def is None:
                     # No crosslink defined for this match
+                    logging.debug(
+                        "    Skipping (crosslink not expected 2: electric boogaloo)",
+                    )
                     continue
-                this_crosslink_atom_idx = match.canonical_atom_name_to_index[
+                this_crosslink_atom_idx = match.match.canonical_atom_name_to_index[
                     this_crosslink_def.atom1
                 ]
 
                 this_crosslink_conects = self.conects[this_crosslink_atom_idx]
                 for other_crosslink_atom_idx in this_crosslink_conects:
-                    other_crosslink_res_idx = atom_idx_to_res_idx[
+                    logging.debug(
+                        f"    checking possible partner {other_crosslink_atom_idx}",
+                    )
+                    other_crosslink_res_idx = self.atom_idx_to_res_idx[
                         other_crosslink_atom_idx
                     ]
-                    other_matches = linkage_matches[other_crosslink_res_idx]
+                    other_matches = list(matches[other_crosslink_res_idx])
                     for other_match in other_matches:
-                        other_crosslink_def = other_match.residue_definition.crosslink
-                        other_crosslink_atom_canonical_name = other_match.atom(
+                        if not isinstance(other_match.match, ResidueMatch):
+                            continue
+                        logging.debug(
+                            f"      in {other_match.match.residue_definition.description}",
+                        )
+                        other_crosslink_def = (
+                            other_match.match.residue_definition.crosslink
+                        )
+                        other_crosslink_atom_canonical_name = other_match.match.atom(
                             other_crosslink_atom_idx,
                         ).name
                         if (
-                            other_match.expect_crosslink
+                            other_match.match.expects_crosslink
                             and other_crosslink_def is not None
                             and other_crosslink_def.flipped() == this_crosslink_def
                             and other_crosslink_def.atom2
                             == other_crosslink_atom_canonical_name
                         ):
+                            logging.debug(
+                                "        crosslink found!",
+                            )
                             # We've found a crosslink!
-                            match.set_crosslink(
+                            # TODO: What if there are multiple possible crosslinks?
+                            #       ATM the last one is assigned, then rejected
+                            #       because the other CONECT records are not
+                            #       satisfied
+                            match.match.set_crosslink(
                                 this_crosslink_atom_idx,
                                 other_crosslink_atom_idx,
                             )
-                            other_match.set_crosslink(
+                            other_match.match.set_crosslink(
                                 other_crosslink_atom_idx,
                                 this_crosslink_atom_idx,
                             )
-        # If there is a crosslink, we know we want it because it's in CONECTs
-        # so filter out anything else
-        for residue_matches in linkage_matches:
-            if any(map(lambda x: x.crosslink is not None, residue_matches)):
-                yielded_matches: list[ResidueMatch] = []
-                for match in residue_matches:
-                    if match.crosslink is not None:
-                        yielded_matches.append(match)
-                yield yielded_matches
+                if match.match.expects_crosslink and match.match.crosslink_idcs is None:
+                    match.reject(
+                        "crosslink expected but no matching crosslink partner could be found",
+                    )
+
+    def match_unknown_molecules(
+        self,
+        matches: Iterable[list[PossibleResidueMatch]],
+        additional_substructures: Iterable[ResidueDefinition],
+    ) -> Iterator[list[PossibleResidueMatch]]:
+        for residue_matches in matches:
+            if not any(residue_matches):
+                res_atom_idcs = residue_matches[0].res_atom_idcs
+                additional_matches: list[PossibleResidueMatch] = []
+                for residue_definition in additional_substructures:
+                    additional_matches.append(
+                        self.subset_matches_residue(
+                            res_atom_idcs,
+                            residue_definition,
+                        ),
+                    )
+                yield residue_matches + additional_matches
             else:
-                yield [match for match in residue_matches if not match.expect_crosslink]
+                yield residue_matches
+
+    def filter_on_conect_records(
+        self,
+        matches: Iterable[list[PossibleResidueMatch]],
+    ) -> None:
+        for residue_matches in matches:
+            for match in residue_matches:
+                if not isinstance(match.match, ResidueMatch):
+                    continue
+
+                expected_bonds: set[tuple[int, int]] = set()
+                for bond in match.match.residue_definition.bonds:
+                    try:
+                        atom1_idx = match.match.canonical_atom_name_to_index[bond.atom1]
+                        atom2_idx = match.match.canonical_atom_name_to_index[bond.atom2]
+                    except KeyError:
+                        # Bond is for a missing leaving atom
+                        continue
+                    expected_bonds.add(sort_tuple((atom1_idx, atom2_idx)))
+                if match.match.crosslink_idcs is not None:
+                    expected_bonds.add(sort_tuple(match.match.crosslink_idcs))
+                if match.match.prior_bond_idcs is not None:
+                    expected_bonds.add(sort_tuple(match.match.prior_bond_idcs))
+                if match.match.posterior_bond_idcs is not None:
+                    expected_bonds.add(sort_tuple(match.match.posterior_bond_idcs))
+
+                found_conects = set(
+                    flatten(
+                        (sort_tuple((i, j)) for j in self.conects[i])
+                        for i in match.res_atom_idcs
+                    ),
+                )
+                if not found_conects.issubset(expected_bonds):
+                    print("rejected")
+                    match.reject(
+                        "found CONECT record that could not be matched with a bond",
+                    )
+
+    def filter_on_consecutive_chain_linkages(
+        self,
+        matches: Iterable[list[PossibleResidueMatch]],
+    ) -> None:
+        """If adjacent residues within a chain can be linked, reject matches that don't link them"""
+        # TODO: Nail down the definition of "Adjacent"
+        for prev_matches, this_matches, next_matches in with_neighbours(matches):
+            this_ptype_idx = next(iter(this_matches)).prototype_index
+            prev_ptype_idx = (
+                next(iter(prev_matches)).prototype_index
+                if prev_matches is not None
+                else None
+            )
+            next_ptype_idx = (
+                next(iter(next_matches)).prototype_index
+                if next_matches is not None
+                else None
+            )
+
+            this_chain = self.chain_id[this_ptype_idx]
+            prev_chain = (
+                self.chain_id[prev_ptype_idx] if prev_ptype_idx is not None else None
+            )
+            next_chain = (
+                self.chain_id[next_ptype_idx] if next_ptype_idx is not None else None
+            )
+
+            this_terminated = self.terminated[this_ptype_idx]
+            prev_terminated = (
+                self.terminated[prev_ptype_idx] if prev_ptype_idx is not None else True
+            )
+
+            can_form_prior_bond = any(
+                m.prior_bond_idcs is not None for m in only_matched(this_matches)
+            )
+            can_form_posterior_bond = any(
+                m.posterior_bond_idcs is not None for m in only_matched(this_matches)
+            )
+
+            prev_is_adjacent = (
+                prev_ptype_idx is not None
+                and prev_chain is not None
+                and prev_chain == this_chain
+                and not prev_terminated
+            )
+            next_is_adjacent = (
+                next_ptype_idx is not None
+                and next_chain is not None
+                and next_chain == this_chain
+                and not this_terminated
+            )
+
+            for match in this_matches:
+                if not isinstance(match.match, ResidueMatch):
+                    continue
+
+                current_match_doesnt_form_prior_bond = (
+                    match.match.prior_bond_idcs is None
+                )
+                current_match_doesnt_form_posterior_bond = (
+                    match.match.posterior_bond_idcs is None
+                )
+
+                if (
+                    can_form_prior_bond
+                    and prev_is_adjacent
+                    and current_match_doesnt_form_prior_bond
+                ):
+                    match.reject(
+                        "adjacent residues in unterminated chain can be linked",
+                    )
+                if (
+                    can_form_posterior_bond
+                    and next_is_adjacent
+                    and current_match_doesnt_form_posterior_bond
+                ):
+                    match.reject(
+                        "adjacent residues in unterminated chain can be linked",
+                    )
+
+    def match_residues(
+        self,
+        residue_database: Mapping[str, Iterable[ResidueDefinition]],
+        additional_substructures: Iterable[ResidueDefinition],
+    ) -> list[list[PossibleResidueMatch]]:
+        matches = list(self.get_name_based_matches(residue_database))
+        # self.rescue_partial_matches_with_conect_element_charge(matches)
+        self.filter_on_polymer_linkages(matches)
+        self.filter_on_crosslinks(matches)
+        matches = list(
+            self.match_unknown_molecules(
+                matches,
+                additional_substructures,
+            ),
+        )
+        self.filter_on_conect_records(matches)
+        self.filter_on_consecutive_chain_linkages(matches)
+        return matches
 
     def __getitem__(self, index: int) -> dict[str, Any]:
         return {

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -733,14 +733,17 @@ class PdbData:
                 )
                 yield match
 
-    def filter_on_consecutive_chain_linkages(
+    def choose_polymer_bonds(
         self,
         this_matches: Sequence[PossibleResidueMatch],
         prev_matches: Sequence[PossibleResidueMatch],
         next_matches: Sequence[PossibleResidueMatch],
         all_matches: Sequence[Sequence[PossibleResidueMatch]],
     ) -> Iterator[PossibleResidueMatch]:
-        """If adjacent residues within a chain can be linked, reject matches that don't link them"""
+        """
+        If adjacent residues within a chain can be linked, reject matches that
+        don't link them; if they are not adjacent, reject those that do.
+        """
         # TODO: Nail down the definition of "Adjacent"
         logging.debug(
             f"Filtering matches for polymer linkages in {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
@@ -813,15 +816,26 @@ class PdbData:
                 f"  Checking {match.description}",
             )
 
-            current_match_doesnt_form_prior_bond = match.prior_bond_idcs is None
-            current_match_doesnt_form_posterior_bond = match.posterior_bond_idcs is None
+            current_match_forms_prior_bond = match.prior_bond_idcs is not None
+            current_match_forms_posterior_bond = match.posterior_bond_idcs is not None
 
             if (
                 can_form_prior_bond
                 and prev_is_adjacent
-                and current_match_doesnt_form_prior_bond
+                and not current_match_forms_prior_bond
             ):
                 reason = "adjacent residues in unterminated chain can be linked"
+                logging.debug(
+                    f"    REJECTED: {reason}",
+                )
+                yield match.reject(reason)
+                continue
+            elif (
+                can_form_prior_bond
+                and not prev_is_adjacent
+                and current_match_forms_prior_bond
+            ):
+                reason = "non-adjacent residues in unterminated chain cannot be linked"
                 logging.debug(
                     f"    REJECTED: {reason}",
                 )
@@ -830,9 +844,20 @@ class PdbData:
             if (
                 can_form_posterior_bond
                 and next_is_adjacent
-                and current_match_doesnt_form_posterior_bond
+                and not current_match_forms_posterior_bond
             ):
                 reason = "adjacent residues in unterminated chain can be linked"
+                logging.debug(
+                    f"    REJECTED: {reason}",
+                )
+                yield match.reject(reason)
+                continue
+            elif (
+                can_form_posterior_bond
+                and not next_is_adjacent
+                and current_match_forms_posterior_bond
+            ):
+                reason = "non-adjacent residues in unterminated chain cannot be linked"
                 logging.debug(
                     f"    REJECTED: {reason}",
                 )
@@ -973,7 +998,7 @@ class PdbData:
                 additional_substructures=additional_substructures,
             ),
             self.filter_on_conect_records,
-            self.filter_on_consecutive_chain_linkages,
+            self.choose_polymer_bonds,
             functools.partial(
                 self.match_unknown_molecules,
                 unknown_molecules=unknown_molecules,

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -14,6 +14,8 @@ from openff.toolkit import Molecule
 from openff.units import elements
 
 from ._matching import (
+    MatchProtocol,
+    MismatchProtocol,
     MoleculeMatch,
     NoResidueDefinitions,
     PossibleResidueMatch,
@@ -271,10 +273,12 @@ class PdbData:
         if len(residue_definition.atoms) < len(res_atom_idcs):
             reason = f"Too few atoms in residue definition ({len(residue_definition.atoms)} < {len(res_atom_idcs)})"
             logging.debug("    Match failed: " + reason)
-            return PossibleResidueMatch.mismatched(
-                residue_definition=residue_definition,
-                index_to_atomdef={i: None for i in res_atom_idcs},
-                reason=reason,
+            return PossibleResidueMatch(
+                ResidueMismatch(
+                    residue_definition=residue_definition,
+                    index_to_atomdef={i: None for i in res_atom_idcs},
+                    reason=reason,
+                ),
             )
 
         # Skip non-(cross)linking definitions with the wrong number of atoms
@@ -288,10 +292,12 @@ class PdbData:
         ):
             reason = "No links and wrong number of atoms"
             logging.debug("    Match failed: " + reason)
-            return PossibleResidueMatch.mismatched(
-                residue_definition=residue_definition,
-                index_to_atomdef={i: None for i in res_atom_idcs},
-                reason=reason,
+            return PossibleResidueMatch(
+                ResidueMismatch(
+                    residue_definition=residue_definition,
+                    index_to_atomdef={i: None for i in res_atom_idcs},
+                    reason=reason,
+                ),
             )
 
         # Get the map from the canonical names to the indices
@@ -302,15 +308,19 @@ class PdbData:
         except KeyError:
             reason = "Name missing from residue definition"
             logging.debug("    Match failed: " + reason)
-            return PossibleResidueMatch.mismatched(
-                residue_definition=residue_definition,
-                index_to_atomdef={i: None for i in res_atom_idcs},
-                reason=reason,
+            return PossibleResidueMatch(
+                ResidueMismatch(
+                    residue_definition=residue_definition,
+                    index_to_atomdef={i: None for i in res_atom_idcs},
+                    reason=reason,
+                ),
             )
 
-        match = PossibleResidueMatch.matched(
-            index_to_atomdef=index_to_atomdef,
-            residue_definition=residue_definition,
+        match = PossibleResidueMatch(
+            ResidueMatch(
+                index_to_atomdef=index_to_atomdef,
+                residue_definition=residue_definition,
+            ),
         )
 
         matched_atoms = {atom.name for atom in index_to_atomdef.values()}
@@ -449,7 +459,8 @@ class PdbData:
                     next_match.residue_definition.prior_bond_linking_atom
                 ]
                 for next_match in only_matched(next_matches)
-                if next_match.residue_definition.linking_bond is not None
+                if isinstance(next_match, ResidueMatch)
+                and next_match.residue_definition.linking_bond is not None
                 and next_match.expects_prior_bond
             }
             neighbour_supported_prior_bonds: dict[BondDefinition, int] = {
@@ -457,7 +468,8 @@ class PdbData:
                     prev_match.residue_definition.posterior_bond_linking_atom
                 ]
                 for prev_match in only_matched(prev_matches)
-                if prev_match.residue_definition.linking_bond is not None
+                if isinstance(prev_match, ResidueMatch)
+                and prev_match.residue_definition.linking_bond is not None
                 and prev_match.expects_posterior_bond
             }
 
@@ -752,10 +764,14 @@ class PdbData:
             )
 
             can_form_prior_bond = any(
-                m.prior_bond_idcs is not None for m in only_matched(this_matches)
+                m.prior_bond_idcs is not None
+                for m in only_matched(this_matches)
+                if isinstance(m, ResidueMatch)
             )
             can_form_posterior_bond = any(
-                m.posterior_bond_idcs is not None for m in only_matched(this_matches)
+                m.posterior_bond_idcs is not None
+                for m in only_matched(this_matches)
+                if isinstance(m, ResidueMatch)
             )
 
             prev_is_adjacent = (
@@ -893,7 +909,7 @@ class PdbData:
         self,
         matches: list[list[PossibleResidueMatch]],
         unknown_molecules: Iterable[Molecule],
-    ) -> Iterator[Sequence[PossibleResidueMatch | MoleculeMatch]]:
+    ) -> Iterator[Sequence[PossibleResidueMatch]]:
         for residue_matches in matches:
             if any(residue_matches):
                 yield residue_matches
@@ -917,12 +933,16 @@ class PdbData:
                     f"  Matched {unk_mol_match}",
                 )
                 yield residue_matches + [
-                    MoleculeMatch(
-                        residue_definition=unk_mol_match,
-                        index_to_atomdef={
-                            i: None
-                            for i in unk_mol_match.properties["pdb_idx_to_mol_atom_idx"]
-                        },
+                    PossibleResidueMatch(
+                        match=MoleculeMatch(
+                            residue_definition=unk_mol_match,
+                            index_to_atomdef={
+                                i: None
+                                for i in unk_mol_match.properties[
+                                    "pdb_idx_to_mol_atom_idx"
+                                ]
+                            },
+                        ),
                     ),
                 ]
 
@@ -931,7 +951,7 @@ class PdbData:
         residue_database: Mapping[str, Iterable[ResidueDefinition]],
         additional_substructures: Iterable[ResidueDefinition],
         unknown_molecules: Iterable[Molecule],
-    ) -> list[Sequence[PossibleResidueMatch | MoleculeMatch]]:
+    ) -> list[Sequence[PossibleResidueMatch]]:
         matches = list(self.get_name_based_matches(residue_database))
         # self.rescue_partial_matches_with_conect_element_charge(matches)
         self.filter_on_polymer_linkages(matches)
@@ -953,18 +973,15 @@ class PdbData:
         residue_database: Mapping[str, Iterable[ResidueDefinition]],
         additional_substructures: Iterable[ResidueDefinition],
         unknown_molecules: Iterable[Molecule],
-    ) -> list[ResidueMatch | MoleculeMatch]:
+    ) -> list[MatchProtocol]:
         logging.debug(
             "Getting all residue matches",
         )
         # List of residue matches, one per residue. This list has one residue
         # match for each residue in the PDB file iff every residue could be
         # identified
-        residues: list[ResidueMatch | MoleculeMatch] = []
-        errors: list[
-            list[ResidueMismatch | NoResidueDefinitions]
-            | list[ResidueMatch | MoleculeMatch]
-        ] = []
+        residues: list[MatchProtocol] = []
+        errors: list[list[MismatchProtocol] | list[MatchProtocol]] = []
         all_residues_successful = True
         for possible_residue_matches in self.match_residues(
             residue_database,
@@ -975,10 +992,10 @@ class PdbData:
                 f"  Checking errors for {self.res_name[possible_residue_matches[0].prototype_index]} {possible_residue_matches[0].res_atom_idcs}",
             )
 
-            matches: list[ResidueMatch | MoleculeMatch] = []
-            mismatches: list[ResidueMismatch | NoResidueDefinitions] = []
+            matches: list[MatchProtocol] = []
+            mismatches: list[MismatchProtocol] = []
             for possible_match in possible_residue_matches:
-                if isinstance(possible_match.match, (ResidueMatch, MoleculeMatch)):
+                if isinstance(possible_match.match, MatchProtocol):
                     matches.append(possible_match.match)
                 else:
                     mismatches.append(possible_match.match)

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from io import TextIOBase
 from os import PathLike
-from typing import IO, Any, DefaultDict, Self
+from typing import IO, Any, DefaultDict, Protocol, Self
 
 from ._utils import __UNSET__, charge_int_or_none, dec_hex, with_neighbours
 from .exceptions import (
@@ -22,11 +22,34 @@ __all__ = [
 
 
 @dataclass(frozen=True)
-class ResidueMatch:
+class ResidueMatchProtocol(Protocol):
+    residue_definition: ResidueDefinition
+    index_to_atomdef: Mapping[int, AtomDefinition | None]
+
+    @cached_property
+    def res_atom_idcs(self) -> set[int]:
+        return set(self.index_to_atomdef)
+
+
+@dataclass(frozen=True)
+class ResidueMismatch(ResidueMatchProtocol):
+    residue_definition: ResidueDefinition
+    index_to_atomdef: Mapping[int, AtomDefinition | None]
+    reason: str
+
+    def __bool__(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class ResidueMatch(ResidueMatchProtocol):
     residue_definition: ResidueDefinition
     index_to_atomdef: dict[int, AtomDefinition]
     crosslink: tuple[int, int] | None = None
     """PDB indices of each bonded atom"""
+
+    def __bool__(self) -> bool:
+        return True
 
     def atom(self, identifier: int | str) -> AtomDefinition:
         """Get an atom definition by name or PDB index"""
@@ -49,15 +72,12 @@ class ResidueMatch:
         object.__setattr__(self, "crosslink", (atom1_idx, atom2_idx))
 
     @cached_property
-    def res_atom_idcs(self) -> set[int]:
-        return set(self.index_to_atomdef)
-
-    @cached_property
     def prototype_index(self) -> int:
         return next(iter(self.index_to_atomdef))
 
     @cached_property
     def missing_atoms(self) -> set[str]:
+        """Atoms present in the residue definition that were not matched"""
         return {
             atom.name
             for atom in self.residue_definition.atoms
@@ -392,7 +412,7 @@ class PdbData:
         self,
         res_atom_idcs: Sequence[int],
         residue_definition: ResidueDefinition,
-    ) -> ResidueMatch | None:
+    ) -> ResidueMismatch | ResidueMatch:
         # Raise an error if the match would be empty - this way the
         # return value's truthiness always reflects whether there was a match
         if len(res_atom_idcs) == 0:
@@ -402,10 +422,13 @@ class PdbData:
 
         # Skip definitions with too few atoms
         if len(residue_definition.atoms) < len(res_atom_idcs):
-            logging.debug(
-                f"    Match failed: Too few atoms in residue definition ({len(residue_definition.atoms)} < {len(res_atom_idcs)})",
+            reason = f"Too few atoms in residue definition ({len(residue_definition.atoms)} < {len(res_atom_idcs)})"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef={i: None for i in res_atom_idcs},
+                reason=reason,
             )
-            return None
 
         # Skip non-(cross)linking definitions with the wrong number of atoms
         if (
@@ -416,8 +439,13 @@ class PdbData:
             )
             != len(res_atom_idcs)
         ):
-            logging.debug("    Match failed: No links and wrong number of atoms")
-            return None
+            reason = "No links and wrong number of atoms"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef={i: None for i in res_atom_idcs},
+                reason=reason,
+            )
 
         # Get the map from the canonical names to the indices
         try:
@@ -425,17 +453,25 @@ class PdbData:
                 i: residue_definition.name_to_atom[self.name[i]] for i in res_atom_idcs
             }
         except KeyError:
-            logging.debug("    Match failed: Name missing from residue definition")
-            return None
+            reason = "Name missing from residue definition"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef={i: None for i in res_atom_idcs},
+                reason=reason,
+            )
 
         matched_atoms = {atom.name for atom in index_to_atomdef.values()}
 
         # Fail to match if any atoms in PDB file got matched to more than one name
         if len(matched_atoms) != len(res_atom_idcs):
-            logging.debug(
-                "    Match failed: Atom definition matched multiple PDB coordinate records",
+            reason = "Atom definition matched multiple PDB coordinate records"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                reason=reason,
             )
-            return None
 
         # This assert should be guaranteed by the above
         assert set(index_to_atomdef.keys()) == set(res_atom_idcs)
@@ -445,8 +481,13 @@ class PdbData:
             self.element[i] != "" and self.element[i].lower() != atom.symbol.lower()
             for i, atom in index_to_atomdef.items()
         ):
-            logging.debug("    Match failed: Element mismatch")
-            return None
+            reason = "Element mismatch"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                reason=reason,
+            )
 
         # PDB files can not be trusted; ignore charges.
         # # Check that charges match, but tolerate missing columns
@@ -465,8 +506,13 @@ class PdbData:
         # is either entirely present or entirely absent
         missing_atom_names = {atom.name for atom in missing_atoms}
         if any(not atom.leaving for atom in missing_atoms):
-            logging.debug("    Match failed: Missing atom is not leaving atom")
-            return None
+            reason = "Missing atom is not leaving atom"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                reason=reason,
+            )
         elif (
             (
                 missing_atom_names.issuperset(
@@ -499,8 +545,13 @@ class PdbData:
                 residue_definition=residue_definition,
             )
         else:
-            logging.debug("    Match failed: Missing atoms do not specify link")
-            return None
+            reason = "Missing atoms do not specify link"
+            logging.debug("    Match failed: " + reason)
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef=index_to_atomdef,
+                reason=reason,
+            )
 
     def get_residue_matches(
         self,
@@ -528,7 +579,7 @@ class PdbData:
                     residue_definition,
                 )
 
-                if match is not None:
+                if isinstance(match, ResidueMatch):
                     residue_matches.append(match)
 
             if len(residue_matches) == 0:
@@ -537,7 +588,7 @@ class PdbData:
                         res_atom_idcs,
                         residue_definition,
                     )
-                    if match is not None:
+                    if isinstance(match, ResidueMatch):
                         residue_matches.append(match)
 
             name_matches.append(residue_matches)

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -1,328 +1,44 @@
 import dataclasses
+import itertools
 import logging
 import warnings
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from io import TextIOBase
 from os import PathLike
-from typing import IO, Any, ClassVar, DefaultDict, Protocol, Self
-from collections.abc import Collection
+from typing import IO, Any, DefaultDict, Self
 
+from openff.toolkit import Molecule
+from openff.units import elements
+
+from ._matching import (
+    MoleculeMatch,
+    NoResidueDefinitions,
+    PossibleResidueMatch,
+    ResidueMatch,
+    ResidueMismatch,
+    only_matched,
+)
 from ._utils import (
     __UNSET__,
     charge_int_or_none,
     dec_hex,
     flatten,
     sort_tuple,
+    unwrap,
     with_neighbours,
 )
 from .exceptions import (
+    PdbResidueMatchError,
     UnknownOrAmbiguousSerialInConectError,
 )
-from .residue import AtomDefinition, BondDefinition, ResidueDefinition
+from .residue import BondDefinition, ResidueDefinition
 
 __all__ = [
-    "ResidueMatch",
     "PdbData",
 ]
-
-
-# TODO: Refactor
-@dataclass(frozen=True)
-class ResidueMatchProtocol(Protocol):
-    residue_definition: ResidueDefinition | str
-    index_to_atomdef: Mapping[int, AtomDefinition | None]
-    is_match: ClassVar[bool]
-
-    @cached_property
-    def res_atom_idcs(self) -> set[int]:
-        return set(self.index_to_atomdef)
-
-    def __bool__(self) -> bool:
-        return self.is_match
-
-    @property
-    def description(self) -> str:
-        if isinstance(self.residue_definition, str):
-            return self.residue_definition
-        else:
-            return self.residue_definition.description
-
-
-@dataclass(frozen=True)
-class NoResidueDefinitions(ResidueMatchProtocol):
-    index_to_atomdef: Mapping[int, None]
-    residue_definition: str
-    is_match = False
-
-    @property
-    def description(self) -> str:
-        return f"No residue definitions for {self.residue_definition}@{list(self.res_atom_idcs)[:1]}"
-
-
-@dataclass(frozen=True)
-class ResidueMismatch(ResidueMatchProtocol):
-    residue_definition: ResidueDefinition
-    index_to_atomdef: Mapping[int, AtomDefinition | None]
-    reasons: list[str]
-    is_match = False
-
-    @property
-    def description(self) -> str:
-        return f"{self.residue_definition.description} failed to match because {self.reasons}"
-
-
-@dataclass(frozen=True)
-class ResidueMatch(ResidueMatchProtocol):
-    residue_definition: ResidueDefinition
-    index_to_atomdef: dict[int, AtomDefinition]
-    prior_bond_idcs: tuple[int, int] | None = None
-    posterior_bond_idcs: tuple[int, int] | None = None
-    crosslink_idcs: tuple[int, int] | None = None
-    """PDB indices of each bonded atom"""
-    is_match = True
-
-    def atom(self, identifier: int | str) -> AtomDefinition:
-        """Get an atom definition by name or PDB index"""
-        if isinstance(identifier, int):
-            return self.index_to_atomdef[identifier]
-        elif isinstance(identifier, str):
-            return self.residue_definition.name_to_atom[identifier]
-        else:
-            raise TypeError(f"unknown identifier type {type(identifier)}")
-
-    def set_crosslink(self, atom1_idx: int, atom2_idx: int) -> None:
-        """Set a match for crosslinking"""
-        if (
-            self.residue_definition.crosslink is None
-            or atom1_idx not in self.res_atom_idcs
-            or self.atom(atom1_idx).name != self.residue_definition.crosslink.atom1
-            or atom2_idx in self.res_atom_idcs
-        ):
-            raise ValueError("bad crosslink index(es)")
-        object.__setattr__(self, "crosslink_idcs", (atom1_idx, atom2_idx))
-
-    def set_prior_bond(self, d: dict[BondDefinition, int]) -> None:
-        if self.residue_definition.linking_bond is None:
-            raise ValueError("cannot set prior bond without linking_bond")
-
-        prior_bond_idcs: tuple[int, int] = (
-            d[self.residue_definition.linking_bond],
-            self.canonical_atom_name_to_index[
-                self.residue_definition.prior_bond_linking_atom
-            ],
-        )
-        object.__setattr__(
-            self,
-            "prior_bond_idcs",
-            prior_bond_idcs,
-        )
-
-    def set_posterior_bond(self, d: dict[BondDefinition, int]) -> None:
-        if self.residue_definition.linking_bond is None:
-            raise ValueError("cannot set posterior bond without linking_bond")
-
-        posterior_bond_idcs: tuple[int, int] = (
-            d[self.residue_definition.linking_bond],
-            self.canonical_atom_name_to_index[
-                self.residue_definition.posterior_bond_linking_atom
-            ],
-        )
-        object.__setattr__(
-            self,
-            "posterior_bond_idcs",
-            posterior_bond_idcs,
-        )
-
-    @cached_property
-    def prototype_index(self) -> int:
-        return next(iter(self.index_to_atomdef))
-
-    @cached_property
-    def missing_atoms(self) -> set[str]:
-        """Atoms present in the residue definition that were not matched"""
-        return {
-            atom.name
-            for atom in self.residue_definition.atoms
-            if atom.name not in self.canonical_atom_name_to_index
-        }
-
-    @cached_property
-    def missing_leaving_atoms(self) -> set[str]:
-        return {
-            atom_name
-            for atom_name in self.missing_atoms
-            if self.atom(atom_name).leaving
-        }
-
-    @cached_property
-    def canonical_atom_name_to_index(self) -> dict[str, int]:
-        return {atom.name: i for i, atom in self.index_to_atomdef.items()}
-
-    @cached_property
-    def expects_prior_bond(self) -> bool:
-        if self.residue_definition.linking_bond is None:
-            return False
-
-        linking_atom = self.residue_definition.prior_bond_linking_atom
-        expected_leaving_atoms = self.residue_definition.prior_bond_leaving_atoms
-
-        return (
-            linking_atom in self.canonical_atom_name_to_index
-            and len(expected_leaving_atoms) > 0
-            and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
-        )
-
-    @cached_property
-    def expects_posterior_bond(self) -> bool:
-        if self.residue_definition.linking_bond is None:
-            return False
-
-        linking_atom = self.residue_definition.posterior_bond_linking_atom
-        expected_leaving_atoms = self.residue_definition.posterior_bond_leaving_atoms
-
-        return (
-            linking_atom in self.canonical_atom_name_to_index
-            and len(expected_leaving_atoms) > 0
-            and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
-        )
-
-    @cached_property
-    def expects_crosslink(self) -> bool:
-        if self.residue_definition.crosslink is None:
-            return False
-
-        linking_atom = self.residue_definition.crosslink.atom1
-        expected_leaving_atoms = self.residue_definition.crosslink_leaving_atoms
-
-        return (
-            linking_atom in self.canonical_atom_name_to_index
-            and len(expected_leaving_atoms) > 0
-            and expected_leaving_atoms.issubset(self.missing_leaving_atoms)
-        )
-
-    def agrees_with(self, other: Self) -> bool:
-        """True if both matches would assign the same chemistry, False otherwise"""
-        if set(self.index_to_atomdef.keys()) != set(other.index_to_atomdef.keys()):
-            return False
-
-        name_map: dict[str, str] = {}
-        for i, self_atom in self.index_to_atomdef.items():
-            other_atom = other.index_to_atomdef[i]
-            if not (
-                self_atom.aromatic == other_atom.aromatic
-                and self_atom.charge == other_atom.charge
-                and self_atom.symbol == other_atom.symbol
-                and self_atom.stereo == other_atom.stereo
-            ):
-                return False
-            name_map[self_atom.name] = other_atom.name
-
-        self_bonds = {
-            (
-                *sorted([name_map[bond.atom1], name_map[bond.atom2]]),
-                bond.aromatic,
-                bond.order,
-                bond.stereo,
-            )
-            for bond in self.residue_definition.bonds
-            if bond.atom1 in self.canonical_atom_name_to_index
-            and bond.atom2 in self.canonical_atom_name_to_index
-        }
-        other_bonds = {
-            (
-                *sorted([bond.atom1, bond.atom2]),
-                bond.aromatic,
-                bond.order,
-                bond.stereo,
-            )
-            for bond in other.residue_definition.bonds
-            if bond.atom1 in self.canonical_atom_name_to_index
-            and bond.atom2 in self.canonical_atom_name_to_index
-        }
-        if self_bonds != other_bonds:
-            return False
-
-        if self.expects_crosslink and (
-            self.crosslink_idcs != other.crosslink_idcs
-            or self.residue_definition.crosslink != other.residue_definition.crosslink
-        ):
-            return False
-
-        if (self.expects_prior_bond or self.expects_posterior_bond) and (
-            self.residue_definition.linking_bond
-            != other.residue_definition.linking_bond
-        ):
-            return False
-
-        return (
-            self.expects_crosslink == other.expects_crosslink
-            and self.expects_prior_bond == other.expects_prior_bond
-            and self.expects_posterior_bond == other.expects_posterior_bond
-        )
-
-
-@dataclass
-class PossibleResidueMatch:
-    match: ResidueMismatch | ResidueMatch | NoResidueDefinitions
-
-    @classmethod
-    def matched(
-        cls,
-        index_to_atomdef: dict[int, AtomDefinition],
-        residue_definition: ResidueDefinition,
-    ) -> Self:
-        return cls(
-            match=ResidueMatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                crosslink_idcs=None,
-            ),
-        )
-
-    @classmethod
-    def mismatched(
-        cls,
-        index_to_atomdef: dict[int, AtomDefinition | None],
-        residue_definition: ResidueDefinition,
-        reason: str,
-    ) -> Self:
-        return cls(
-            match=ResidueMismatch(
-                residue_definition=residue_definition,
-                index_to_atomdef=index_to_atomdef,
-                reasons=[reason],
-            ),
-        )
-
-    def reject(self, reason: str) -> Self:
-        if isinstance(self.match, ResidueMatch):
-            self.match = ResidueMismatch(
-                residue_definition=self.match.residue_definition,
-                index_to_atomdef=self.match.index_to_atomdef,
-                reasons=[*self._reasons(), reason],
-            )
-        return self
-
-    @property
-    def res_atom_idcs(self) -> set[int]:
-        return self.match.res_atom_idcs
-
-    @property
-    def prototype_index(self) -> int:
-        return next(iter(self.match.index_to_atomdef))
-
-    def _reasons(self) -> list[str]:
-        return self.match.reasons if isinstance(self.match, ResidueMismatch) else []
-
-    def __bool__(self) -> bool:
-        return bool(self.match)
-
-
-def only_matched(iterable: Iterable[PossibleResidueMatch]) -> Iterable[ResidueMatch]:
-    return (p.match for p in iterable if isinstance(p.match, ResidueMatch))
 
 
 @dataclass
@@ -345,6 +61,7 @@ class PdbData:
     element: list[str] = field(default_factory=list)
     charge: list[int | None] = field(default_factory=list)
     terminated: list[bool] = field(default_factory=list)
+    res_idx: list[int] | None = None
     serial_to_index: DefaultDict[str, list[int]] = field(
         default_factory=lambda: defaultdict(list),
     )
@@ -502,6 +219,8 @@ class PdbData:
     def residue_indices(self) -> Iterator[tuple[int, ...]]:
         indices = []
         prev = None
+        res_idx = 0
+        self.res_idx = []
         for atom_idx, (alt_loc, *residue_info) in enumerate(
             zip(
                 self.alt_loc,
@@ -529,7 +248,9 @@ class PdbData:
                 indices.append(atom_idx)
             else:
                 yield tuple(indices)
+                res_idx += 1
                 indices = [atom_idx]
+            self.res_idx.append(res_idx)
             prev = residue_info
 
         yield tuple(indices)
@@ -664,17 +385,6 @@ class PdbData:
             reason = "Missing atoms do not specify link"
             logging.debug("    Match failed: " + reason)
             return match.reject(reason)
-
-    def get_residue_matches(
-        self,
-        residue_database: Mapping[str, Iterable[ResidueDefinition]],
-        additional_substructures: Iterable[ResidueDefinition],
-    ) -> Iterator[list[ResidueMatch]]:
-        possible_matches = self.match_residues(
-            residue_database,
-            additional_substructures,
-        )
-        return (list(only_matched(matches)) for matches in possible_matches)
 
     @cached_property
     def atom_idx_to_res_idx(self) -> dict[int, int]:
@@ -912,13 +622,16 @@ class PdbData:
                         "crosslink expected but no matching crosslink partner could be found",
                     )
 
-    def match_unknown_molecules(
+    def match_additional_substructures(
         self,
         matches: Iterable[list[PossibleResidueMatch]],
         additional_substructures: Iterable[ResidueDefinition],
     ) -> Iterator[list[PossibleResidueMatch]]:
         for residue_matches in matches:
             if not any(residue_matches):
+                logging.debug(
+                    f"Matching additional_substructures to {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+                )
                 res_atom_idcs = residue_matches[0].res_atom_idcs
                 additional_matches: list[PossibleResidueMatch] = []
                 for residue_definition in additional_substructures:
@@ -928,6 +641,9 @@ class PdbData:
                             residue_definition,
                         ),
                     )
+                logging.debug(
+                    "  Done",
+                )
                 yield residue_matches + additional_matches
             else:
                 yield residue_matches
@@ -937,9 +653,16 @@ class PdbData:
         matches: Iterable[list[PossibleResidueMatch]],
     ) -> None:
         for residue_matches in matches:
+            logging.debug(
+                f"Filtering matches on CONECT records for {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+            )
             for match in residue_matches:
                 if not isinstance(match.match, ResidueMatch):
                     continue
+
+                logging.debug(
+                    f"  Checking match {match.match.description}",
+                )
 
                 expected_bonds: set[tuple[int, int]] = set()
                 for bond in match.match.residue_definition.bonds:
@@ -964,9 +687,15 @@ class PdbData:
                     ),
                 )
                 if not found_conects.issubset(expected_bonds):
-                    print("rejected")
+                    logging.debug(
+                        "    REJECTED: CONECT record but no bond",
+                    )
                     match.reject(
                         "found CONECT record that could not be matched with a bond",
+                    )
+                else:
+                    logging.debug(
+                        "    ACCEPTED",
                     )
 
     def filter_on_consecutive_chain_linkages(
@@ -976,6 +705,10 @@ class PdbData:
         """If adjacent residues within a chain can be linked, reject matches that don't link them"""
         # TODO: Nail down the definition of "Adjacent"
         for prev_matches, this_matches, next_matches in with_neighbours(matches):
+            logging.debug(
+                f"Filtering matches for polymer linkages in {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+            )
+
             this_ptype_idx = next(iter(this_matches)).prototype_index
             prev_ptype_idx = (
                 next(iter(prev_matches)).prototype_index
@@ -1021,9 +754,26 @@ class PdbData:
                 and not this_terminated
             )
 
+            logging.debug(
+                f"  {can_form_prior_bond=}",
+            )
+            logging.debug(
+                f"  {can_form_posterior_bond=}",
+            )
+            logging.debug(
+                f"  {prev_is_adjacent=}",
+            )
+            logging.debug(
+                f"  {next_is_adjacent=}",
+            )
+
             for match in this_matches:
                 if not isinstance(match.match, ResidueMatch):
                     continue
+
+                logging.debug(
+                    f"  Checking {match.match.description}",
+                )
 
                 current_match_doesnt_form_prior_bond = (
                     match.match.prior_bond_idcs is None
@@ -1037,36 +787,219 @@ class PdbData:
                     and prev_is_adjacent
                     and current_match_doesnt_form_prior_bond
                 ):
-                    match.reject(
-                        "adjacent residues in unterminated chain can be linked",
+                    reason = "adjacent residues in unterminated chain can be linked"
+                    logging.debug(
+                        f"    REJECTED: {reason}",
                     )
+                    match.reject(reason)
                 if (
                     can_form_posterior_bond
                     and next_is_adjacent
                     and current_match_doesnt_form_posterior_bond
                 ):
-                    match.reject(
-                        "adjacent residues in unterminated chain can be linked",
+                    reason = "adjacent residues in unterminated chain can be linked"
+                    logging.debug(
+                        f"    REJECTED: {reason}",
                     )
+                    match.reject(reason)
+                if match:
+                    logging.debug(
+                        "    ACCEPTED",
+                    )
+
+    def _match_unknown_molecules_to_indices(
+        self,
+        indices: Sequence[int],
+        unknown_molecules: Iterable[Molecule],
+    ) -> Molecule | None:
+        conects: set[tuple[int, int]] = set()
+        pdb_idx_to_mol_idx: dict[int, int] = {}
+        pdbmol = Molecule()
+        for pdb_index in indices:
+            pdb_idx_to_mol_idx[pdb_index] = pdbmol.add_atom(
+                atomic_number=elements.NUMBERS[self.element[pdb_index]],
+                formal_charge=self.charge[pdb_index] or 0,
+                is_aromatic=False,
+                stereochemistry=None,
+                name=self.name[pdb_index],
+                metadata={
+                    "leaving": False,
+                    **self._generate_atom_metadata(pdb_index),
+                },
+            )
+            for conect_idx in self.conects[pdb_index]:
+                conects.add(sort_tuple((pdb_index, conect_idx)))
+
+        for a, b in conects:
+            try:
+                pdbmol.add_bond(
+                    atom1=pdb_idx_to_mol_idx[a],
+                    atom2=pdb_idx_to_mol_idx[b],
+                    bond_order=1,
+                    is_aromatic=False,
+                )
+            except KeyError:
+                # Bonds between this residue and another are not supported yet
+                return None
+
+        for molecule in unknown_molecules:
+            (match_found, mapping) = Molecule.are_isomorphic(
+                molecule,
+                pdbmol,
+                return_atom_map=True,
+                aromatic_matching=False,
+                formal_charge_matching=False,
+                bond_order_matching=False,
+                atom_stereochemistry_matching=False,
+                bond_stereochemistry_matching=False,
+                strip_pyrimidal_n_atom_stereo=True,
+            )
+            if match_found:
+                assert mapping is not None
+                molecule = molecule.remap(mapping)
+                for atom, pdbatom in zip(molecule.atoms, pdbmol.atoms):
+                    atom.metadata.update(pdbatom.metadata)
+                    atom.name = pdbatom.name
+                molecule.generate_conformers(n_conformers=0, clear_existing=True)
+                molecule.properties["pdb_idx_to_mol_atom_idx"] = pdb_idx_to_mol_idx
+
+                molecule_pdb_indices = [
+                    atom.metadata["pdb_index"] for atom in molecule.atoms
+                ]
+                assert molecule_pdb_indices == sorted(molecule_pdb_indices)
+
+                return molecule
+        else:
+            return None
+
+    def _match_unknown_molecules(
+        self,
+        matches: list[list[PossibleResidueMatch]],
+        unknown_molecules: Iterable[Molecule],
+    ) -> Iterator[Sequence[PossibleResidueMatch | MoleculeMatch]]:
+        for residue_matches in matches:
+            if any(residue_matches):
+                yield residue_matches
+                continue
+
+            logging.debug(
+                f"Matching unknown_molecules against {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+            )
+
+            unk_mol_match = self._match_unknown_molecules_to_indices(
+                indices=residue_matches[0].res_atom_idcs,
+                unknown_molecules=unknown_molecules,
+            )
+            if unk_mol_match is None:
+                logging.debug(
+                    "  No match",
+                )
+                yield residue_matches
+            else:
+                logging.debug(
+                    f"  Matched {unk_mol_match}",
+                )
+                yield residue_matches + [
+                    MoleculeMatch(
+                        residue_definition=unk_mol_match,
+                        index_to_atomdef={
+                            i: None
+                            for i in unk_mol_match.properties["pdb_idx_to_mol_atom_idx"]
+                        },
+                    ),
+                ]
 
     def match_residues(
         self,
         residue_database: Mapping[str, Iterable[ResidueDefinition]],
         additional_substructures: Iterable[ResidueDefinition],
-    ) -> list[list[PossibleResidueMatch]]:
+        unknown_molecules: Iterable[Molecule],
+    ) -> list[Sequence[PossibleResidueMatch | MoleculeMatch]]:
         matches = list(self.get_name_based_matches(residue_database))
         # self.rescue_partial_matches_with_conect_element_charge(matches)
         self.filter_on_polymer_linkages(matches)
         self.filter_on_crosslinks(matches)
         matches = list(
-            self.match_unknown_molecules(
+            self.match_additional_substructures(
                 matches,
                 additional_substructures,
             ),
         )
         self.filter_on_conect_records(matches)
         self.filter_on_consecutive_chain_linkages(matches)
+        matches = list(self._match_unknown_molecules(matches, unknown_molecules))
+        logging.debug("------")
         return matches
+
+    def get_residue_matches(
+        self,
+        residue_database: Mapping[str, Iterable[ResidueDefinition]],
+        additional_substructures: Iterable[ResidueDefinition],
+        unknown_molecules: Iterable[Molecule],
+    ) -> list[ResidueMatch | MoleculeMatch]:
+        logging.debug(
+            "Getting all residue matches",
+        )
+        # List of residue matches, one per residue. This list has one residue
+        # match for each residue in the PDB file iff every residue could be
+        # identified
+        residues: list[ResidueMatch | MoleculeMatch] = []
+        errors: list[
+            list[ResidueMismatch | NoResidueDefinitions]
+            | list[ResidueMatch | MoleculeMatch]
+        ] = []
+        all_residues_successful = True
+        for possible_residue_matches in self.match_residues(
+            residue_database,
+            additional_substructures,
+            unknown_molecules,
+        ):
+            logging.debug(
+                f"  Checking errors for {self.res_name[possible_residue_matches[0].prototype_index]} {possible_residue_matches[0].res_atom_idcs}",
+            )
+
+            matches: list[ResidueMatch | MoleculeMatch] = []
+            mismatches: list[ResidueMismatch | NoResidueDefinitions] = []
+            for possible_match in possible_residue_matches:
+                if isinstance(possible_match.match, (ResidueMatch, MoleculeMatch)):
+                    matches.append(possible_match.match)
+                else:
+                    mismatches.append(possible_match.match)
+
+            if len(matches) == 0:
+                logging.debug(
+                    "    FAILURE: no successful matches; PDB loading has failed",
+                )
+                # No matches, PDB loading has failed
+                all_residues_successful = False
+                errors.append(mismatches)
+            elif len(matches) == 1:
+                logging.debug(
+                    "    SUCCESS: 1 successful match",
+                )
+                # 1 match, this residue has succeeded
+                residues.append(unwrap(matches))
+            elif all(a.agrees_with(b) for a, b in itertools.pairwise(matches)):
+                logging.debug(
+                    "    SUCCESS: multiple matches with consistent chemistry",
+                )
+                # Multiple matches that specify identical chemistry, this residue has succeeded
+                residues.append(next(iter(matches)))
+            else:
+                logging.debug(
+                    "    FAILURE: multiple matches with inconsistent chemistry; PDB loading has failed",
+                )
+                # Multiple matches that specify different chemistry, PDB loading has failed
+                all_residues_successful = False
+                errors.append(matches)
+
+        if all_residues_successful:
+            logging.debug(
+                "All residues successfully matched",
+            )
+            return residues
+        else:
+            raise PdbResidueMatchError(self, errors)
 
     def __getitem__(self, index: int) -> dict[str, Any]:
         return {
@@ -1078,15 +1011,22 @@ class PdbData:
         self,
         pdb_index: int,
     ) -> dict[str, str | int]:
+        if self.res_idx is None:
+            list(self.residue_indices)
+            assert self.res_idx is not None, (
+                "Iterating over residue indices sets res_idx"
+            )
+
         try:
-            res_seq = dec_hex(self.res_seq[pdb_index])
+            res_number = dec_hex(self.res_seq[pdb_index])
         except ValueError:
-            res_seq = self.res_seq[pdb_index]
+            res_number = self.res_idx[pdb_index]
 
         return {
             "residue_name": self.res_name[pdb_index],
-            "residue_number": self.res_seq[pdb_index],
-            "res_seq": res_seq,
+            "residue_number": res_number,
+            "res_seq": self.res_seq[pdb_index],
+            "residue_index": self.res_idx[pdb_index],
             "insertion_code": self.i_code[pdb_index],
             "chain_id": self.chain_id[pdb_index],
             "pdb_index": pdb_index,

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -438,6 +438,8 @@ class PdbData:
                 logging.debug(
                     f"Beginning link-based match of {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
                 )
+            else:
+                continue
             # neighbour_supported_posterior_bonds and
             # neighbour_supported_prior_bonds are maps from possible linking
             # bonds in this residue to the atom index (in the neighbouring
@@ -475,6 +477,11 @@ class PdbData:
                 )
                 or len(valid_prev_matches) == 0
             )
+            prev_residue_terminated = (
+                len(prev_matches) > 0
+                and self.terminated[prev_matches[0].prototype_index]
+            )
+            this_residue_terminated = self.terminated[this_matches[0].prototype_index]
             if len(list(only_matched(this_matches))) != 0:
                 logging.debug(
                     f"  {neighbour_supported_posterior_bonds=}",
@@ -503,6 +510,11 @@ class PdbData:
                         logging.debug(f"    Match failed: {reason}")
                         match.reject(reason)
                         continue
+                    elif prev_residue_terminated:
+                        reason = "Prior bond expected but cannot form polymer bond across TER record"
+                        logging.debug(f"    Match failed: {reason}")
+                        match.reject(reason)
+                        continue
                     else:
                         match.match.set_prior_bond(neighbour_supported_prior_bonds)
                 elif not neighbours_support_molecule_start:
@@ -519,6 +531,11 @@ class PdbData:
                         reason = (
                             "Posterior bond expected but not supported by neighbours"
                         )
+                        logging.debug(f"    Match failed: {reason}")
+                        match.reject(reason)
+                        continue
+                    elif this_residue_terminated:
+                        reason = "Posterior bond expected but cannot form polymer bond across TER record"
                         logging.debug(f"    Match failed: {reason}")
                         match.reject(reason)
                         continue

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -15,13 +15,13 @@ from openff.toolkit import Molecule
 from openff.units import elements
 
 from ._matching import (
-    MatchProtocol,
     MismatchProtocol,
     MoleculeMatch,
     NoResidueDefinitions,
     PossibleResidueMatch,
     ResidueMatch,
     ResidueMismatch,
+    SuccessfulMatch,
     only_matched,
 )
 from ._utils import (
@@ -274,12 +274,10 @@ class PdbData:
         if len(residue_definition.atoms) < len(res_atom_idcs):
             reason = f"Too few atoms in residue definition ({len(residue_definition.atoms)} < {len(res_atom_idcs)})"
             logging.debug("    Match failed: " + reason)
-            return PossibleResidueMatch(
-                ResidueMismatch(
-                    residue_definition=residue_definition,
-                    index_to_atomdef={i: None for i in res_atom_idcs},
-                    reason=reason,
-                ),
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef={i: None for i in res_atom_idcs},
+                reason=reason,
             )
 
         # Skip non-(cross)linking definitions with the wrong number of atoms
@@ -293,12 +291,10 @@ class PdbData:
         ):
             reason = "No links and wrong number of atoms"
             logging.debug("    Match failed: " + reason)
-            return PossibleResidueMatch(
-                ResidueMismatch(
-                    residue_definition=residue_definition,
-                    index_to_atomdef={i: None for i in res_atom_idcs},
-                    reason=reason,
-                ),
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef={i: None for i in res_atom_idcs},
+                reason=reason,
             )
 
         # Get the map from the canonical names to the indices
@@ -309,19 +305,15 @@ class PdbData:
         except KeyError:
             reason = "Name missing from residue definition"
             logging.debug("    Match failed: " + reason)
-            return PossibleResidueMatch(
-                ResidueMismatch(
-                    residue_definition=residue_definition,
-                    index_to_atomdef={i: None for i in res_atom_idcs},
-                    reason=reason,
-                ),
+            return ResidueMismatch(
+                residue_definition=residue_definition,
+                index_to_atomdef={i: None for i in res_atom_idcs},
+                reason=reason,
             )
 
-        match = PossibleResidueMatch(
-            ResidueMatch(
-                index_to_atomdef=index_to_atomdef,
-                residue_definition=residue_definition,
-            ),
+        match = ResidueMatch(
+            index_to_atomdef=index_to_atomdef,
+            residue_definition=residue_definition,
         )
 
         matched_atoms = {atom.name for atom in index_to_atomdef.values()}
@@ -429,11 +421,9 @@ class PdbData:
                 yield matches
             else:
                 yield [
-                    PossibleResidueMatch(
-                        match=NoResidueDefinitions(
-                            residue_definition=res_name,
-                            index_to_atomdef={i: None for i in res_atom_idcs},
-                        ),
+                    NoResidueDefinitions(
+                        residue_definition=res_name,
+                        index_to_atomdef={i: None for i in res_atom_idcs},
                     ),
                 ]
 
@@ -505,15 +495,15 @@ class PdbData:
                 f"  {neighbours_support_molecule_start=}",
             )
         for match in this_matches:
-            if not isinstance(match.match, ResidueMatch):
+            if not isinstance(match, ResidueMatch):
                 yield match
                 continue
             logging.debug(
-                f"  Attempting link-based match against {match.match.residue_definition.description}",
+                f"  Attempting link-based match against {match.residue_definition.description}",
             )
-            if match.match.expects_prior_bond:
+            if match.expects_prior_bond:
                 if (
-                    match.match.residue_definition.linking_bond
+                    match.residue_definition.linking_bond
                     not in neighbour_supported_prior_bonds
                 ):
                     reason = "Prior bond expected but not supported by neighbours"
@@ -526,16 +516,16 @@ class PdbData:
                     yield match.reject(reason)
                     continue
                 else:
-                    match.match.set_prior_bond(neighbour_supported_prior_bonds)
+                    match.set_prior_bond(neighbour_supported_prior_bonds)
             elif not neighbours_support_molecule_start:
                 reason = "Prior bond not permitted but required by neighbours"
                 logging.debug(f"    Match failed: {reason}")
                 yield match.reject(reason)
                 continue
 
-            if match.match.expects_posterior_bond:
+            if match.expects_posterior_bond:
                 if (
-                    match.match.residue_definition.linking_bond
+                    match.residue_definition.linking_bond
                     not in neighbour_supported_posterior_bonds
                 ):
                     reason = "Posterior bond expected but not supported by neighbours"
@@ -548,7 +538,7 @@ class PdbData:
                     yield match.reject(reason)
                     continue
                 else:
-                    match.match.set_posterior_bond(
+                    match.set_posterior_bond(
                         neighbour_supported_posterior_bonds,
                     )
             elif not neighbours_support_molecule_end:
@@ -577,26 +567,26 @@ class PdbData:
             yield from this_matches
             return
         for match in this_matches:
-            if not isinstance(match.match, ResidueMatch):
+            if not isinstance(match, ResidueMatch):
                 yield match
                 continue
             logging.debug(
-                f"  Attempting crosslink-based match against {match.match.residue_definition.description}",
+                f"  Attempting crosslink-based match against {match.residue_definition.description}",
             )
-            if match.match.crosslink_idcs is not None:
+            if match.crosslink_idcs is not None:
                 # This match's crosslink has already been assigned
                 logging.debug(
                     "    Skipping (crosslink already assigned)",
                 )
                 yield match
                 continue
-            if not match.match.expects_crosslink:
+            if not match.expects_crosslink:
                 logging.debug(
                     "    Skipping (crosslink not expected)",
                 )
                 yield match
                 continue
-            this_crosslink_def = match.match.residue_definition.crosslink
+            this_crosslink_def = match.residue_definition.crosslink
             if this_crosslink_def is None:
                 # No crosslink defined for this match
                 logging.debug(
@@ -604,7 +594,7 @@ class PdbData:
                 )
                 yield match
                 continue
-            this_crosslink_atom_idx = match.match.canonical_atom_name_to_index[
+            this_crosslink_atom_idx = match.canonical_atom_name_to_index[
                 this_crosslink_def.atom1
             ]
 
@@ -618,17 +608,17 @@ class PdbData:
                 ]
                 other_matches = list(all_matches[other_crosslink_res_idx])
                 for other_match in other_matches:
-                    if not isinstance(other_match.match, ResidueMatch):
+                    if not isinstance(other_match, ResidueMatch):
                         continue
                     logging.debug(
-                        f"      in {other_match.match.residue_definition.description}",
+                        f"      in {other_match.residue_definition.description}",
                     )
-                    other_crosslink_def = other_match.match.residue_definition.crosslink
-                    other_crosslink_atom_canonical_name = other_match.match.atom(
+                    other_crosslink_def = other_match.residue_definition.crosslink
+                    other_crosslink_atom_canonical_name = other_match.atom(
                         other_crosslink_atom_idx,
                     ).name
                     if (
-                        other_match.match.expects_crosslink
+                        other_match.expects_crosslink
                         and other_crosslink_def is not None
                         and other_crosslink_def.flipped() == this_crosslink_def
                         and other_crosslink_def.atom2
@@ -642,15 +632,15 @@ class PdbData:
                         #       ATM the last one is assigned, then rejected
                         #       because the other CONECT records are not
                         #       satisfied
-                        match.match.set_crosslink(
+                        match.set_crosslink(
                             this_crosslink_atom_idx,
                             other_crosslink_atom_idx,
                         )
-                        other_match.match.set_crosslink(
+                        other_match.set_crosslink(
                             other_crosslink_atom_idx,
                             this_crosslink_atom_idx,
                         )
-            if match.match.expects_crosslink and match.match.crosslink_idcs is None:
+            if match.expects_crosslink and match.crosslink_idcs is None:
                 yield match.reject(
                     "crosslink expected but no matching crosslink partner could be found",
                 )
@@ -691,29 +681,29 @@ class PdbData:
             f"Filtering matches on CONECT records for {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
         )
         for match in this_matches:
-            if not isinstance(match.match, ResidueMatch):
+            if not isinstance(match, ResidueMatch):
                 yield match
                 continue
 
             logging.debug(
-                f"  Checking match {match.match.description}",
+                f"  Checking match {match.description}",
             )
 
             expected_bonds: set[tuple[int, int]] = set()
-            for bond in match.match.residue_definition.bonds:
+            for bond in match.residue_definition.bonds:
                 try:
-                    atom1_idx = match.match.canonical_atom_name_to_index[bond.atom1]
-                    atom2_idx = match.match.canonical_atom_name_to_index[bond.atom2]
+                    atom1_idx = match.canonical_atom_name_to_index[bond.atom1]
+                    atom2_idx = match.canonical_atom_name_to_index[bond.atom2]
                 except KeyError:
                     # Bond is for a missing leaving atom
                     continue
                 expected_bonds.add(sort_tuple((atom1_idx, atom2_idx)))
-            if match.match.crosslink_idcs is not None:
-                expected_bonds.add(sort_tuple(match.match.crosslink_idcs))
-            if match.match.prior_bond_idcs is not None:
-                expected_bonds.add(sort_tuple(match.match.prior_bond_idcs))
-            if match.match.posterior_bond_idcs is not None:
-                expected_bonds.add(sort_tuple(match.match.posterior_bond_idcs))
+            if match.crosslink_idcs is not None:
+                expected_bonds.add(sort_tuple(match.crosslink_idcs))
+            if match.prior_bond_idcs is not None:
+                expected_bonds.add(sort_tuple(match.prior_bond_idcs))
+            if match.posterior_bond_idcs is not None:
+                expected_bonds.add(sort_tuple(match.posterior_bond_idcs))
 
             found_conects = set(
                 flatten(
@@ -806,18 +796,16 @@ class PdbData:
         )
 
         for match in this_matches:
-            if not isinstance(match.match, ResidueMatch):
+            if not isinstance(match, ResidueMatch):
                 yield match
                 continue
 
             logging.debug(
-                f"  Checking {match.match.description}",
+                f"  Checking {match.description}",
             )
 
-            current_match_doesnt_form_prior_bond = match.match.prior_bond_idcs is None
-            current_match_doesnt_form_posterior_bond = (
-                match.match.posterior_bond_idcs is None
-            )
+            current_match_doesnt_form_prior_bond = match.prior_bond_idcs is None
+            current_match_doesnt_form_posterior_bond = match.posterior_bond_idcs is None
 
             if (
                 can_form_prior_bond
@@ -942,14 +930,12 @@ class PdbData:
                 f"  Matched {unk_mol_match}",
             )
             yield from (
-                PossibleResidueMatch(
-                    match=MoleculeMatch(
-                        residue_definition=unk_mol_match,
-                        index_to_atomdef={
-                            i: None
-                            for i in unk_mol_match.properties["pdb_idx_to_mol_atom_idx"]
-                        },
-                    ),
+                MoleculeMatch(
+                    residue_definition=unk_mol_match,
+                    index_to_atomdef={
+                        i: None
+                        for i in unk_mol_match.properties["pdb_idx_to_mol_atom_idx"]
+                    },
                 ),
             )
 
@@ -1007,15 +993,15 @@ class PdbData:
         residue_database: Mapping[str, Iterable[ResidueDefinition]],
         additional_substructures: Iterable[ResidueDefinition],
         unknown_molecules: Iterable[Molecule],
-    ) -> list[MatchProtocol]:
+    ) -> list[SuccessfulMatch]:
         logging.debug(
             "Getting all residue matches",
         )
         # List of residue matches, one per residue. This list has one residue
         # match for each residue in the PDB file iff every residue could be
         # identified
-        residues: list[MatchProtocol] = []
-        errors: list[list[MismatchProtocol] | list[MatchProtocol]] = []
+        residues: list[SuccessfulMatch] = []
+        errors: list[list[MismatchProtocol] | list[SuccessfulMatch]] = []
         all_residues_successful = True
         for possible_residue_matches in self.match_residues(
             residue_database,
@@ -1026,13 +1012,13 @@ class PdbData:
                 f"  Checking errors for {self.res_name[possible_residue_matches[0].prototype_index]} {possible_residue_matches[0].res_atom_idcs}",
             )
 
-            matches: list[MatchProtocol] = []
+            matches: list[SuccessfulMatch] = []
             mismatches: list[MismatchProtocol] = []
             for possible_match in possible_residue_matches:
-                if isinstance(possible_match.match, MatchProtocol):
-                    matches.append(possible_match.match)
+                if isinstance(possible_match, SuccessfulMatch):
+                    matches.append(possible_match)
                 else:
-                    mismatches.append(possible_match.match)
+                    mismatches.append(possible_match)
 
             if len(matches) == 0:
                 logging.debug(

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -29,6 +29,7 @@ from ._utils import (
     charge_int_or_none,
     dec_hex,
     flatten,
+    is_repeated,
     no_none_in_values,
     sort_tuple,
     unwrap,
@@ -206,15 +207,12 @@ class PdbData:
                         conects[b_idx].add(a_idx)
         return conects
 
-    @property
-    def residue_indices(self) -> Iterator[tuple[int, ...]]:
+    def _residue_indices_inner(self) -> Iterator[tuple[int, ...]]:
         if len(self.model) == 0:
             return
         first_model: int | None = self.model[0]
         indices = []
         prev = None
-        res_idx = 0
-        self.res_idx = []
         for atom_idx, (alt_loc, terminated, *residue_info) in enumerate(
             zip(
                 self.alt_loc,
@@ -245,20 +243,43 @@ class PdbData:
                 indices.append(atom_idx)
             else:
                 yield tuple(indices)
-                res_idx += 1
                 indices = [atom_idx]
-
-            self.res_idx.append(res_idx)
 
             if terminated:
                 yield tuple(indices)
                 indices = []
-                res_idx += 1
 
             prev = residue_info
 
         if len(indices) > 0:
             yield tuple(indices)
+
+    @property
+    def residue_indices(self) -> Iterator[tuple[int, ...]]:
+        this_res_idx: int = 0
+        self.res_idx = []
+        for res_atom_idcs in self._residue_indices_inner():
+            res_atom_names = [self.name[i] for i in res_atom_idcs]
+            subresidue_n_atoms = len(set(res_atom_names))
+            n_subresidues = len(res_atom_idcs) // subresidue_n_atoms
+            subresidues: list[tuple[int, ...]]
+            if (
+                is_repeated(n_subresidues, res_atom_names)
+                and is_repeated(n_subresidues, [self.element[i] for i in res_atom_idcs])
+                and is_repeated(n_subresidues, [self.charge[i] for i in res_atom_idcs])
+            ):
+                subresidues = [
+                    tuple(res_atom_idcs[i : i + subresidue_n_atoms])
+                    for i in range(0, len(res_atom_idcs), subresidue_n_atoms)
+                ]
+            else:
+                subresidues = [res_atom_idcs]
+
+            for subres_atom_idcs in subresidues:
+                for _ in subres_atom_idcs:
+                    self.res_idx.append(this_res_idx)
+                yield subres_atom_idcs
+                this_res_idx += 1
 
     def subset_matches_residue(
         self,

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -29,6 +29,7 @@ from ._utils import (
     charge_int_or_none,
     dec_hex,
     flatten,
+    no_none_in_values,
     sort_tuple,
     unwrap,
     with_neighbours,
@@ -143,25 +144,12 @@ class PdbData:
                 model_n = int(line[10:14])
             if line.startswith("ENDMDL "):
                 model_n = None
-            if line.startswith("HETATM") or line.startswith("ATOM  "):
+            if line.startswith(("ATOM  ", "HETATM")):
                 data._append_coord_line(line)
                 data.line_no[-1] = i + 1
                 data.model[-1] = model_n
             if line.startswith("TER   "):
-                terminated_resname = data.res_name[-1]
-                terminated_chainid = data.chain_id[-1]
-                terminated_resseq = data.res_seq[-1]
-                terminated_icode = data.i_code[-1]
-                for i in range(len(data.res_name) - 1, 0, -1):
-                    if (
-                        data.res_name[i] == terminated_resname
-                        and data.chain_id[i] == terminated_chainid
-                        and data.res_seq[i] == terminated_resseq
-                        and data.i_code[i] == terminated_icode
-                    ):
-                        data.terminated[i] = True
-                    else:
-                        break
+                data.terminated[-1] = True
             if line.startswith("CRYST1"):
                 data.cryst1_a = float(line[6:15])
                 data.cryst1_b = float(line[15:24])
@@ -220,18 +208,23 @@ class PdbData:
 
     @property
     def residue_indices(self) -> Iterator[tuple[int, ...]]:
+        if len(self.model) == 0:
+            return
+        first_model: int | None = self.model[0]
         indices = []
         prev = None
         res_idx = 0
         self.res_idx = []
-        for atom_idx, (alt_loc, *residue_info) in enumerate(
+        for atom_idx, (alt_loc, terminated, *residue_info) in enumerate(
             zip(
                 self.alt_loc,
+                self.terminated,
                 self.model,
                 self.res_name,
                 self.chain_id,
                 self.res_seq,
                 self.i_code,
+                strict=True,
             ),
         ):
             if alt_loc != "":
@@ -241,22 +234,31 @@ class PdbData:
                 )
                 if alt_loc != "A":
                     continue
-            if prev is not None and residue_info[0] != prev[0]:
+            if residue_info[0] != first_model:
                 # TODO: Support multi-model files
                 warnings.warn(
                     "Multi-model files not supported; topology will reflect first model",
                 )
                 break
-            if prev == residue_info or prev is None:
+
+            if prev == residue_info or prev is None or len(indices) == 0:
                 indices.append(atom_idx)
             else:
                 yield tuple(indices)
                 res_idx += 1
                 indices = [atom_idx]
+
             self.res_idx.append(res_idx)
+
+            if terminated:
+                yield tuple(indices)
+                indices = []
+                res_idx += 1
+
             prev = residue_info
 
-        yield tuple(indices)
+        if len(indices) > 0:
+            yield tuple(indices)
 
     def subset_matches_residue(
         self,
@@ -298,12 +300,16 @@ class PdbData:
             )
 
         # Get the map from the canonical names to the indices
-        try:
-            index_to_atomdef = {
-                i: residue_definition.name_to_atom[self.name[i]] for i in res_atom_idcs
-            }
-        except KeyError:
-            reason = "Name missing from residue definition"
+        index_to_atomdef = {
+            i: residue_definition.name_to_atom.get(self.name[i], None)
+            for i in res_atom_idcs
+        }
+        if not no_none_in_values(index_to_atomdef):
+            reason = "Unknown atoms missing from residue definition " + repr(
+                tuple(
+                    self.name[i] for i, atom in index_to_atomdef.items() if atom is None
+                ),
+            )
             logging.debug("    Match failed: " + reason)
             return ResidueMismatch(
                 residue_definition=residue_definition,
@@ -353,7 +359,10 @@ class PdbData:
         # is either entirely present or entirely absent
         missing_atom_names = {atom.name for atom in missing_atoms}
         if any(not atom.leaving for atom in missing_atoms):
-            reason = "Missing atom is not leaving atom"
+            reason = "Missing atom(s) are not leaving atoms"
+            reason += (
+                f" {tuple({atom.name for atom in missing_atoms if not atom.leaving})}"
+            )
             logging.debug("    Match failed: " + reason)
             return match.reject(reason)
         elif (

--- a/openff/pablo/_pdb_data.py
+++ b/openff/pablo/_pdb_data.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import itertools
 import logging
 import warnings
@@ -8,7 +9,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from io import TextIOBase
 from os import PathLike
-from typing import IO, Any, DefaultDict, Self
+from typing import IO, Any, DefaultDict, Protocol, Self
 
 from openff.toolkit import Molecule
 from openff.units import elements
@@ -438,407 +439,413 @@ class PdbData:
 
     def filter_on_polymer_linkages(
         self,
-        matches: Sequence[Sequence[PossibleResidueMatch]],
-    ) -> None:
-        for prev_matches, this_matches, next_matches in with_neighbours(
-            matches,
-            default=(),
-        ):
-            if len(list(only_matched(this_matches))) != 0:
-                logging.debug(
-                    f"Beginning link-based match of {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
-                )
-            else:
+        this_matches: Sequence[PossibleResidueMatch],
+        prev_matches: Sequence[PossibleResidueMatch],
+        next_matches: Sequence[PossibleResidueMatch],
+        all_matches: Sequence[Sequence[PossibleResidueMatch]],
+    ) -> Iterator[PossibleResidueMatch]:
+        if len(list(only_matched(this_matches))) != 0:
+            logging.debug(
+                f"Beginning link-based match of {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+            )
+        else:
+            yield from this_matches
+            return
+        # neighbour_supported_posterior_bonds and
+        # neighbour_supported_prior_bonds are maps from possible linking
+        # bonds in this residue to the atom index (in the neighbouring
+        # residue) where the linking atom can be found
+        neighbour_supported_posterior_bonds: dict[BondDefinition, int] = {
+            next_match.residue_definition.linking_bond: next_match.canonical_atom_name_to_index[
+                next_match.residue_definition.prior_bond_linking_atom
+            ]
+            for next_match in only_matched(next_matches)
+            if isinstance(next_match, ResidueMatch)
+            and next_match.residue_definition.linking_bond is not None
+            and next_match.expects_prior_bond
+        }
+        neighbour_supported_prior_bonds: dict[BondDefinition, int] = {
+            prev_match.residue_definition.linking_bond: prev_match.canonical_atom_name_to_index[
+                prev_match.residue_definition.posterior_bond_linking_atom
+            ]
+            for prev_match in only_matched(prev_matches)
+            if isinstance(prev_match, ResidueMatch)
+            and prev_match.residue_definition.linking_bond is not None
+            and prev_match.expects_posterior_bond
+        }
+
+        valid_next_matches = list(only_matched(next_matches))
+        neighbours_support_molecule_end = (
+            any(not next_match.expects_prior_bond for next_match in valid_next_matches)
+            or len(valid_next_matches) == 0
+        )
+        valid_prev_matches = list(only_matched(prev_matches))
+        neighbours_support_molecule_start = (
+            any(
+                not prev_match.expects_posterior_bond
+                for prev_match in valid_prev_matches
+            )
+            or len(valid_prev_matches) == 0
+        )
+        prev_residue_terminated = (
+            len(prev_matches) > 0 and self.terminated[prev_matches[0].prototype_index]
+        )
+        this_residue_terminated = self.terminated[this_matches[0].prototype_index]
+        if len(list(only_matched(this_matches))) != 0:
+            logging.debug(
+                f"  {neighbour_supported_posterior_bonds=}",
+            )
+            logging.debug(
+                f"  {neighbour_supported_prior_bonds=}",
+            )
+            logging.debug(
+                f"  {neighbours_support_molecule_end=}",
+            )
+            logging.debug(
+                f"  {neighbours_support_molecule_start=}",
+            )
+        for match in this_matches:
+            if not isinstance(match.match, ResidueMatch):
+                yield match
                 continue
-            # neighbour_supported_posterior_bonds and
-            # neighbour_supported_prior_bonds are maps from possible linking
-            # bonds in this residue to the atom index (in the neighbouring
-            # residue) where the linking atom can be found
-            neighbour_supported_posterior_bonds: dict[BondDefinition, int] = {
-                next_match.residue_definition.linking_bond: next_match.canonical_atom_name_to_index[
-                    next_match.residue_definition.prior_bond_linking_atom
-                ]
-                for next_match in only_matched(next_matches)
-                if isinstance(next_match, ResidueMatch)
-                and next_match.residue_definition.linking_bond is not None
-                and next_match.expects_prior_bond
-            }
-            neighbour_supported_prior_bonds: dict[BondDefinition, int] = {
-                prev_match.residue_definition.linking_bond: prev_match.canonical_atom_name_to_index[
-                    prev_match.residue_definition.posterior_bond_linking_atom
-                ]
-                for prev_match in only_matched(prev_matches)
-                if isinstance(prev_match, ResidueMatch)
-                and prev_match.residue_definition.linking_bond is not None
-                and prev_match.expects_posterior_bond
-            }
-
-            valid_next_matches = list(only_matched(next_matches))
-            neighbours_support_molecule_end = (
-                any(
-                    not next_match.expects_prior_bond
-                    for next_match in valid_next_matches
-                )
-                or len(valid_next_matches) == 0
+            logging.debug(
+                f"  Attempting link-based match against {match.match.residue_definition.description}",
             )
-            valid_prev_matches = list(only_matched(prev_matches))
-            neighbours_support_molecule_start = (
-                any(
-                    not prev_match.expects_posterior_bond
-                    for prev_match in valid_prev_matches
-                )
-                or len(valid_prev_matches) == 0
-            )
-            prev_residue_terminated = (
-                len(prev_matches) > 0
-                and self.terminated[prev_matches[0].prototype_index]
-            )
-            this_residue_terminated = self.terminated[this_matches[0].prototype_index]
-            if len(list(only_matched(this_matches))) != 0:
-                logging.debug(
-                    f"  {neighbour_supported_posterior_bonds=}",
-                )
-                logging.debug(
-                    f"  {neighbour_supported_prior_bonds=}",
-                )
-                logging.debug(
-                    f"  {neighbours_support_molecule_end=}",
-                )
-                logging.debug(
-                    f"  {neighbours_support_molecule_start=}",
-                )
-            for match in this_matches:
-                if not isinstance(match.match, ResidueMatch):
-                    continue
-                logging.debug(
-                    f"  Attempting link-based match against {match.match.residue_definition.description}",
-                )
-                if match.match.expects_prior_bond:
-                    if (
-                        match.match.residue_definition.linking_bond
-                        not in neighbour_supported_prior_bonds
-                    ):
-                        reason = "Prior bond expected but not supported by neighbours"
-                        logging.debug(f"    Match failed: {reason}")
-                        match.reject(reason)
-                        continue
-                    elif prev_residue_terminated:
-                        reason = "Prior bond expected but cannot form polymer bond across TER record"
-                        logging.debug(f"    Match failed: {reason}")
-                        match.reject(reason)
-                        continue
-                    else:
-                        match.match.set_prior_bond(neighbour_supported_prior_bonds)
-                elif not neighbours_support_molecule_start:
-                    reason = "Prior bond not permitted but required by neighbours"
+            if match.match.expects_prior_bond:
+                if (
+                    match.match.residue_definition.linking_bond
+                    not in neighbour_supported_prior_bonds
+                ):
+                    reason = "Prior bond expected but not supported by neighbours"
                     logging.debug(f"    Match failed: {reason}")
-                    match.reject(reason)
+                    yield match.reject(reason)
                     continue
-
-                if match.match.expects_posterior_bond:
-                    if (
-                        match.match.residue_definition.linking_bond
-                        not in neighbour_supported_posterior_bonds
-                    ):
-                        reason = (
-                            "Posterior bond expected but not supported by neighbours"
-                        )
-                        logging.debug(f"    Match failed: {reason}")
-                        match.reject(reason)
-                        continue
-                    elif this_residue_terminated:
-                        reason = "Posterior bond expected but cannot form polymer bond across TER record"
-                        logging.debug(f"    Match failed: {reason}")
-                        match.reject(reason)
-                        continue
-                    else:
-                        match.match.set_posterior_bond(
-                            neighbour_supported_posterior_bonds,
-                        )
-                elif not neighbours_support_molecule_end:
-                    reason = "Posterior bond not expected but required by neighbours"
+                elif prev_residue_terminated:
+                    reason = "Prior bond expected but cannot form polymer bond across TER record"
                     logging.debug(f"    Match failed: {reason}")
-                    match.reject(reason)
+                    yield match.reject(reason)
                     continue
+                else:
+                    match.match.set_prior_bond(neighbour_supported_prior_bonds)
+            elif not neighbours_support_molecule_start:
+                reason = "Prior bond not permitted but required by neighbours"
+                logging.debug(f"    Match failed: {reason}")
+                yield match.reject(reason)
+                continue
 
-                logging.debug("    Accepted")
+            if match.match.expects_posterior_bond:
+                if (
+                    match.match.residue_definition.linking_bond
+                    not in neighbour_supported_posterior_bonds
+                ):
+                    reason = "Posterior bond expected but not supported by neighbours"
+                    logging.debug(f"    Match failed: {reason}")
+                    yield match.reject(reason)
+                    continue
+                elif this_residue_terminated:
+                    reason = "Posterior bond expected but cannot form polymer bond across TER record"
+                    logging.debug(f"    Match failed: {reason}")
+                    yield match.reject(reason)
+                    continue
+                else:
+                    match.match.set_posterior_bond(
+                        neighbour_supported_posterior_bonds,
+                    )
+            elif not neighbours_support_molecule_end:
+                reason = "Posterior bond not expected but required by neighbours"
+                logging.debug(f"    Match failed: {reason}")
+                yield match.reject(reason)
+                continue
+
+            logging.debug("    Accepted")
+            yield match
 
     def filter_on_crosslinks(
         self,
-        matches: Sequence[Sequence[PossibleResidueMatch]],
-    ) -> None:
+        this_matches: Sequence[PossibleResidueMatch],
+        prev_matches: Sequence[PossibleResidueMatch],
+        next_matches: Sequence[PossibleResidueMatch],
+        all_matches: Sequence[Sequence[PossibleResidueMatch]],
+    ) -> Iterator[PossibleResidueMatch]:
         # Check for crosslinks
         # TODO: This could be simplified if we required crosslinking atoms not to have synonyms
-        for residue_matches in matches:
-            if len(list(only_matched(residue_matches))) != 0:
+        if len(list(only_matched(this_matches))) != 0:
+            logging.debug(
+                f"Assigning crosslinks for {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+            )
+        else:
+            yield from this_matches
+            return
+        for match in this_matches:
+            if not isinstance(match.match, ResidueMatch):
+                yield match
+                continue
+            logging.debug(
+                f"  Attempting crosslink-based match against {match.match.residue_definition.description}",
+            )
+            if match.match.crosslink_idcs is not None:
+                # This match's crosslink has already been assigned
                 logging.debug(
-                    f"Assigning crosslinks for {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+                    "    Skipping (crosslink already assigned)",
                 )
-            for match in residue_matches:
-                if not isinstance(match.match, ResidueMatch):
-                    continue
+                yield match
+                continue
+            if not match.match.expects_crosslink:
                 logging.debug(
-                    f"  Attempting crosslink-based match against {match.match.residue_definition.description}",
+                    "    Skipping (crosslink not expected)",
                 )
-                if match.match.crosslink_idcs is not None:
-                    # This match's crosslink has already been assigned
-                    logging.debug(
-                        "    Skipping (crosslink already assigned)",
-                    )
-                    continue
-                if not match.match.expects_crosslink:
-                    logging.debug(
-                        "    Skipping (crosslink not expected)",
-                    )
-                    continue
-                this_crosslink_def = match.match.residue_definition.crosslink
-                if this_crosslink_def is None:
-                    # No crosslink defined for this match
-                    logging.debug(
-                        "    Skipping (crosslink not expected 2: electric boogaloo)",
-                    )
-                    continue
-                this_crosslink_atom_idx = match.match.canonical_atom_name_to_index[
-                    this_crosslink_def.atom1
-                ]
+                yield match
+                continue
+            this_crosslink_def = match.match.residue_definition.crosslink
+            if this_crosslink_def is None:
+                # No crosslink defined for this match
+                logging.debug(
+                    "    Skipping (crosslink not expected 2: electric boogaloo)",
+                )
+                yield match
+                continue
+            this_crosslink_atom_idx = match.match.canonical_atom_name_to_index[
+                this_crosslink_def.atom1
+            ]
 
-                this_crosslink_conects = self.conects[this_crosslink_atom_idx]
-                for other_crosslink_atom_idx in this_crosslink_conects:
+            this_crosslink_conects = self.conects[this_crosslink_atom_idx]
+            for other_crosslink_atom_idx in this_crosslink_conects:
+                logging.debug(
+                    f"    checking possible partner {other_crosslink_atom_idx}",
+                )
+                other_crosslink_res_idx = self.atom_idx_to_res_idx[
+                    other_crosslink_atom_idx
+                ]
+                other_matches = list(all_matches[other_crosslink_res_idx])
+                for other_match in other_matches:
+                    if not isinstance(other_match.match, ResidueMatch):
+                        continue
                     logging.debug(
-                        f"    checking possible partner {other_crosslink_atom_idx}",
+                        f"      in {other_match.match.residue_definition.description}",
                     )
-                    other_crosslink_res_idx = self.atom_idx_to_res_idx[
-                        other_crosslink_atom_idx
-                    ]
-                    other_matches = list(matches[other_crosslink_res_idx])
-                    for other_match in other_matches:
-                        if not isinstance(other_match.match, ResidueMatch):
-                            continue
+                    other_crosslink_def = other_match.match.residue_definition.crosslink
+                    other_crosslink_atom_canonical_name = other_match.match.atom(
+                        other_crosslink_atom_idx,
+                    ).name
+                    if (
+                        other_match.match.expects_crosslink
+                        and other_crosslink_def is not None
+                        and other_crosslink_def.flipped() == this_crosslink_def
+                        and other_crosslink_def.atom2
+                        == other_crosslink_atom_canonical_name
+                    ):
                         logging.debug(
-                            f"      in {other_match.match.residue_definition.description}",
+                            "        crosslink found!",
                         )
-                        other_crosslink_def = (
-                            other_match.match.residue_definition.crosslink
-                        )
-                        other_crosslink_atom_canonical_name = other_match.match.atom(
+                        # We've found a crosslink!
+                        # TODO: What if there are multiple possible crosslinks?
+                        #       ATM the last one is assigned, then rejected
+                        #       because the other CONECT records are not
+                        #       satisfied
+                        match.match.set_crosslink(
+                            this_crosslink_atom_idx,
                             other_crosslink_atom_idx,
-                        ).name
-                        if (
-                            other_match.match.expects_crosslink
-                            and other_crosslink_def is not None
-                            and other_crosslink_def.flipped() == this_crosslink_def
-                            and other_crosslink_def.atom2
-                            == other_crosslink_atom_canonical_name
-                        ):
-                            logging.debug(
-                                "        crosslink found!",
-                            )
-                            # We've found a crosslink!
-                            # TODO: What if there are multiple possible crosslinks?
-                            #       ATM the last one is assigned, then rejected
-                            #       because the other CONECT records are not
-                            #       satisfied
-                            match.match.set_crosslink(
-                                this_crosslink_atom_idx,
-                                other_crosslink_atom_idx,
-                            )
-                            other_match.match.set_crosslink(
-                                other_crosslink_atom_idx,
-                                this_crosslink_atom_idx,
-                            )
-                if match.match.expects_crosslink and match.match.crosslink_idcs is None:
-                    match.reject(
-                        "crosslink expected but no matching crosslink partner could be found",
-                    )
+                        )
+                        other_match.match.set_crosslink(
+                            other_crosslink_atom_idx,
+                            this_crosslink_atom_idx,
+                        )
+            if match.match.expects_crosslink and match.match.crosslink_idcs is None:
+                yield match.reject(
+                    "crosslink expected but no matching crosslink partner could be found",
+                )
+            else:
+                yield match
 
     def match_additional_substructures(
         self,
-        matches: Iterable[list[PossibleResidueMatch]],
+        this_matches: Sequence[PossibleResidueMatch],
+        prev_matches: Sequence[PossibleResidueMatch],
+        next_matches: Sequence[PossibleResidueMatch],
+        all_matches: Sequence[Sequence[PossibleResidueMatch]],
         additional_substructures: Iterable[ResidueDefinition],
-    ) -> Iterator[list[PossibleResidueMatch]]:
-        for residue_matches in matches:
-            if not any(residue_matches):
-                logging.debug(
-                    f"Matching additional_substructures to {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+    ) -> Iterator[PossibleResidueMatch]:
+        yield from this_matches
+        if not any(this_matches):
+            logging.debug(
+                f"Matching additional_substructures to {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+            )
+            res_atom_idcs = this_matches[0].res_atom_idcs
+            for residue_definition in additional_substructures:
+                yield self.subset_matches_residue(
+                    res_atom_idcs,
+                    residue_definition,
                 )
-                res_atom_idcs = residue_matches[0].res_atom_idcs
-                additional_matches: list[PossibleResidueMatch] = []
-                for residue_definition in additional_substructures:
-                    additional_matches.append(
-                        self.subset_matches_residue(
-                            res_atom_idcs,
-                            residue_definition,
-                        ),
-                    )
-                logging.debug(
-                    "  Done",
-                )
-                yield residue_matches + additional_matches
-            else:
-                yield residue_matches
+            logging.debug(
+                "  Done",
+            )
 
     def filter_on_conect_records(
         self,
-        matches: Iterable[list[PossibleResidueMatch]],
-    ) -> None:
-        for residue_matches in matches:
+        this_matches: Sequence[PossibleResidueMatch],
+        prev_matches: Sequence[PossibleResidueMatch],
+        next_matches: Sequence[PossibleResidueMatch],
+        all_matches: Sequence[Sequence[PossibleResidueMatch]],
+    ) -> Iterator[PossibleResidueMatch]:
+        logging.debug(
+            f"Filtering matches on CONECT records for {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+        )
+        for match in this_matches:
+            if not isinstance(match.match, ResidueMatch):
+                yield match
+                continue
+
             logging.debug(
-                f"Filtering matches on CONECT records for {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+                f"  Checking match {match.match.description}",
             )
-            for match in residue_matches:
-                if not isinstance(match.match, ResidueMatch):
+
+            expected_bonds: set[tuple[int, int]] = set()
+            for bond in match.match.residue_definition.bonds:
+                try:
+                    atom1_idx = match.match.canonical_atom_name_to_index[bond.atom1]
+                    atom2_idx = match.match.canonical_atom_name_to_index[bond.atom2]
+                except KeyError:
+                    # Bond is for a missing leaving atom
                     continue
+                expected_bonds.add(sort_tuple((atom1_idx, atom2_idx)))
+            if match.match.crosslink_idcs is not None:
+                expected_bonds.add(sort_tuple(match.match.crosslink_idcs))
+            if match.match.prior_bond_idcs is not None:
+                expected_bonds.add(sort_tuple(match.match.prior_bond_idcs))
+            if match.match.posterior_bond_idcs is not None:
+                expected_bonds.add(sort_tuple(match.match.posterior_bond_idcs))
 
+            found_conects = set(
+                flatten(
+                    (sort_tuple((i, j)) for j in self.conects[i])
+                    for i in match.res_atom_idcs
+                ),
+            )
+            if not found_conects.issubset(expected_bonds):
                 logging.debug(
-                    f"  Checking match {match.match.description}",
+                    "    REJECTED: CONECT record but no bond",
                 )
-
-                expected_bonds: set[tuple[int, int]] = set()
-                for bond in match.match.residue_definition.bonds:
-                    try:
-                        atom1_idx = match.match.canonical_atom_name_to_index[bond.atom1]
-                        atom2_idx = match.match.canonical_atom_name_to_index[bond.atom2]
-                    except KeyError:
-                        # Bond is for a missing leaving atom
-                        continue
-                    expected_bonds.add(sort_tuple((atom1_idx, atom2_idx)))
-                if match.match.crosslink_idcs is not None:
-                    expected_bonds.add(sort_tuple(match.match.crosslink_idcs))
-                if match.match.prior_bond_idcs is not None:
-                    expected_bonds.add(sort_tuple(match.match.prior_bond_idcs))
-                if match.match.posterior_bond_idcs is not None:
-                    expected_bonds.add(sort_tuple(match.match.posterior_bond_idcs))
-
-                found_conects = set(
-                    flatten(
-                        (sort_tuple((i, j)) for j in self.conects[i])
-                        for i in match.res_atom_idcs
-                    ),
+                yield match.reject(
+                    "found CONECT record that could not be matched with a bond",
                 )
-                if not found_conects.issubset(expected_bonds):
-                    logging.debug(
-                        "    REJECTED: CONECT record but no bond",
-                    )
-                    match.reject(
-                        "found CONECT record that could not be matched with a bond",
-                    )
-                else:
-                    logging.debug(
-                        "    ACCEPTED",
-                    )
+            else:
+                logging.debug(
+                    "    ACCEPTED",
+                )
+                yield match
 
     def filter_on_consecutive_chain_linkages(
         self,
-        matches: Iterable[list[PossibleResidueMatch]],
-    ) -> None:
+        this_matches: Sequence[PossibleResidueMatch],
+        prev_matches: Sequence[PossibleResidueMatch],
+        next_matches: Sequence[PossibleResidueMatch],
+        all_matches: Sequence[Sequence[PossibleResidueMatch]],
+    ) -> Iterator[PossibleResidueMatch]:
         """If adjacent residues within a chain can be linked, reject matches that don't link them"""
         # TODO: Nail down the definition of "Adjacent"
-        for prev_matches, this_matches, next_matches in with_neighbours(matches):
+        logging.debug(
+            f"Filtering matches for polymer linkages in {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+        )
+
+        this_ptype_idx = next(iter(this_matches)).prototype_index
+        prev_ptype_idx = (
+            prev_matches[0].prototype_index if len(prev_matches) > 0 else None
+        )
+        next_ptype_idx = (
+            next_matches[0].prototype_index if len(next_matches) > 0 else None
+        )
+
+        this_chain = self.chain_id[this_ptype_idx]
+        prev_chain = (
+            self.chain_id[prev_ptype_idx] if prev_ptype_idx is not None else None
+        )
+        next_chain = (
+            self.chain_id[next_ptype_idx] if next_ptype_idx is not None else None
+        )
+
+        this_terminated = self.terminated[this_ptype_idx]
+        prev_terminated = (
+            self.terminated[prev_ptype_idx] if prev_ptype_idx is not None else True
+        )
+
+        can_form_prior_bond = any(
+            m.prior_bond_idcs is not None
+            for m in only_matched(this_matches)
+            if isinstance(m, ResidueMatch)
+        )
+        can_form_posterior_bond = any(
+            m.posterior_bond_idcs is not None
+            for m in only_matched(this_matches)
+            if isinstance(m, ResidueMatch)
+        )
+
+        prev_is_adjacent = (
+            prev_ptype_idx is not None
+            and prev_chain is not None
+            and prev_chain == this_chain
+            and not prev_terminated
+        )
+        next_is_adjacent = (
+            next_ptype_idx is not None
+            and next_chain is not None
+            and next_chain == this_chain
+            and not this_terminated
+        )
+
+        logging.debug(
+            f"  {can_form_prior_bond=}",
+        )
+        logging.debug(
+            f"  {can_form_posterior_bond=}",
+        )
+        logging.debug(
+            f"  {prev_is_adjacent=}",
+        )
+        logging.debug(
+            f"  {next_is_adjacent=}",
+        )
+
+        for match in this_matches:
+            if not isinstance(match.match, ResidueMatch):
+                yield match
+                continue
+
             logging.debug(
-                f"Filtering matches for polymer linkages in {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+                f"  Checking {match.match.description}",
             )
 
-            this_ptype_idx = next(iter(this_matches)).prototype_index
-            prev_ptype_idx = (
-                next(iter(prev_matches)).prototype_index
-                if prev_matches is not None
-                else None
-            )
-            next_ptype_idx = (
-                next(iter(next_matches)).prototype_index
-                if next_matches is not None
-                else None
+            current_match_doesnt_form_prior_bond = match.match.prior_bond_idcs is None
+            current_match_doesnt_form_posterior_bond = (
+                match.match.posterior_bond_idcs is None
             )
 
-            this_chain = self.chain_id[this_ptype_idx]
-            prev_chain = (
-                self.chain_id[prev_ptype_idx] if prev_ptype_idx is not None else None
-            )
-            next_chain = (
-                self.chain_id[next_ptype_idx] if next_ptype_idx is not None else None
-            )
-
-            this_terminated = self.terminated[this_ptype_idx]
-            prev_terminated = (
-                self.terminated[prev_ptype_idx] if prev_ptype_idx is not None else True
-            )
-
-            can_form_prior_bond = any(
-                m.prior_bond_idcs is not None
-                for m in only_matched(this_matches)
-                if isinstance(m, ResidueMatch)
-            )
-            can_form_posterior_bond = any(
-                m.posterior_bond_idcs is not None
-                for m in only_matched(this_matches)
-                if isinstance(m, ResidueMatch)
-            )
-
-            prev_is_adjacent = (
-                prev_ptype_idx is not None
-                and prev_chain is not None
-                and prev_chain == this_chain
-                and not prev_terminated
-            )
-            next_is_adjacent = (
-                next_ptype_idx is not None
-                and next_chain is not None
-                and next_chain == this_chain
-                and not this_terminated
-            )
-
-            logging.debug(
-                f"  {can_form_prior_bond=}",
-            )
-            logging.debug(
-                f"  {can_form_posterior_bond=}",
-            )
-            logging.debug(
-                f"  {prev_is_adjacent=}",
-            )
-            logging.debug(
-                f"  {next_is_adjacent=}",
-            )
-
-            for match in this_matches:
-                if not isinstance(match.match, ResidueMatch):
-                    continue
-
+            if (
+                can_form_prior_bond
+                and prev_is_adjacent
+                and current_match_doesnt_form_prior_bond
+            ):
+                reason = "adjacent residues in unterminated chain can be linked"
                 logging.debug(
-                    f"  Checking {match.match.description}",
+                    f"    REJECTED: {reason}",
                 )
-
-                current_match_doesnt_form_prior_bond = (
-                    match.match.prior_bond_idcs is None
+                yield match.reject(reason)
+                continue
+            if (
+                can_form_posterior_bond
+                and next_is_adjacent
+                and current_match_doesnt_form_posterior_bond
+            ):
+                reason = "adjacent residues in unterminated chain can be linked"
+                logging.debug(
+                    f"    REJECTED: {reason}",
                 )
-                current_match_doesnt_form_posterior_bond = (
-                    match.match.posterior_bond_idcs is None
+                yield match.reject(reason)
+                continue
+            if match:
+                logging.debug(
+                    "    ACCEPTED",
                 )
-
-                if (
-                    can_form_prior_bond
-                    and prev_is_adjacent
-                    and current_match_doesnt_form_prior_bond
-                ):
-                    reason = "adjacent residues in unterminated chain can be linked"
-                    logging.debug(
-                        f"    REJECTED: {reason}",
-                    )
-                    match.reject(reason)
-                if (
-                    can_form_posterior_bond
-                    and next_is_adjacent
-                    and current_match_doesnt_form_posterior_bond
-                ):
-                    reason = "adjacent residues in unterminated chain can be linked"
-                    logging.debug(
-                        f"    REJECTED: {reason}",
-                    )
-                    match.reject(reason)
-                if match:
-                    logging.debug(
-                        "    ACCEPTED",
-                    )
+            yield match
 
     def _match_unknown_molecules_to_indices(
         self,
@@ -905,66 +912,93 @@ class PdbData:
         else:
             return None
 
-    def _match_unknown_molecules(
+    def match_unknown_molecules(
         self,
-        matches: list[list[PossibleResidueMatch]],
+        this_matches: Sequence[PossibleResidueMatch],
+        prev_matches: Sequence[PossibleResidueMatch],
+        next_matches: Sequence[PossibleResidueMatch],
+        all_matches: Sequence[Sequence[PossibleResidueMatch]],
         unknown_molecules: Iterable[Molecule],
-    ) -> Iterator[Sequence[PossibleResidueMatch]]:
-        for residue_matches in matches:
-            if any(residue_matches):
-                yield residue_matches
-                continue
+    ) -> Iterator[PossibleResidueMatch]:
+        yield from this_matches
 
+        if any(this_matches):
+            return
+
+        logging.debug(
+            f"Matching unknown_molecules against {self.res_name[this_matches[0].prototype_index]} {this_matches[0].res_atom_idcs}",
+        )
+
+        unk_mol_match = self._match_unknown_molecules_to_indices(
+            indices=this_matches[0].res_atom_idcs,
+            unknown_molecules=unknown_molecules,
+        )
+        if unk_mol_match is None:
             logging.debug(
-                f"Matching unknown_molecules against {self.res_name[residue_matches[0].prototype_index]} {residue_matches[0].res_atom_idcs}",
+                "  No match",
             )
-
-            unk_mol_match = self._match_unknown_molecules_to_indices(
-                indices=residue_matches[0].res_atom_idcs,
-                unknown_molecules=unknown_molecules,
+        else:
+            logging.debug(
+                f"  Matched {unk_mol_match}",
             )
-            if unk_mol_match is None:
-                logging.debug(
-                    "  No match",
-                )
-                yield residue_matches
-            else:
-                logging.debug(
-                    f"  Matched {unk_mol_match}",
-                )
-                yield residue_matches + [
-                    PossibleResidueMatch(
-                        match=MoleculeMatch(
-                            residue_definition=unk_mol_match,
-                            index_to_atomdef={
-                                i: None
-                                for i in unk_mol_match.properties[
-                                    "pdb_idx_to_mol_atom_idx"
-                                ]
-                            },
-                        ),
+            yield from (
+                PossibleResidueMatch(
+                    match=MoleculeMatch(
+                        residue_definition=unk_mol_match,
+                        index_to_atomdef={
+                            i: None
+                            for i in unk_mol_match.properties["pdb_idx_to_mol_atom_idx"]
+                        },
                     ),
-                ]
+                ),
+            )
 
     def match_residues(
         self,
         residue_database: Mapping[str, Iterable[ResidueDefinition]],
         additional_substructures: Iterable[ResidueDefinition],
         unknown_molecules: Iterable[Molecule],
-    ) -> list[Sequence[PossibleResidueMatch]]:
+    ) -> list[list[PossibleResidueMatch]]:
         matches = list(self.get_name_based_matches(residue_database))
-        # self.rescue_partial_matches_with_conect_element_charge(matches)
-        self.filter_on_polymer_linkages(matches)
-        self.filter_on_crosslinks(matches)
-        matches = list(
-            self.match_additional_substructures(
-                matches,
-                additional_substructures,
+
+        class Filter(Protocol):
+            def __call__(
+                self,
+                this_matches: Sequence[PossibleResidueMatch],
+                prev_matches: Sequence[PossibleResidueMatch],
+                next_matches: Sequence[PossibleResidueMatch],
+                all_matches: Sequence[Sequence[PossibleResidueMatch]],
+            ) -> Iterator[PossibleResidueMatch]: ...
+
+        match_filters: list[Filter] = [
+            self.filter_on_polymer_linkages,
+            self.filter_on_crosslinks,
+            functools.partial(
+                self.match_additional_substructures,
+                additional_substructures=additional_substructures,
             ),
-        )
-        self.filter_on_conect_records(matches)
-        self.filter_on_consecutive_chain_linkages(matches)
-        matches = list(self._match_unknown_molecules(matches, unknown_molecules))
+            self.filter_on_conect_records,
+            self.filter_on_consecutive_chain_linkages,
+            functools.partial(
+                self.match_unknown_molecules,
+                unknown_molecules=unknown_molecules,
+            ),
+        ]
+        for match_filter in match_filters:
+            matches = [
+                list(
+                    match_filter(
+                        this_matches=this_matches,
+                        prev_matches=prev_matches,
+                        next_matches=next_matches,
+                        all_matches=matches,
+                    ),
+                )
+                for prev_matches, this_matches, next_matches in with_neighbours(
+                    matches,
+                    default=(),
+                )
+            ]
         logging.debug("------")
         return matches
 

--- a/openff/pablo/_tests/conftest.py
+++ b/openff/pablo/_tests/conftest.py
@@ -299,7 +299,7 @@ def gly_def_zwitterionic() -> ResidueDefinition:
 def cys_match(cys_def: ResidueDefinition) -> ResidueMatch:
     return ResidueMatch(
         residue_definition=cys_def,
-        crosslink=None,
+        crosslink_idcs=None,
         index_to_atomdef={i: atom for i, atom in enumerate(cys_def.atoms)},
     )
 
@@ -309,7 +309,7 @@ def cys_match_no_leaving(cys_def: ResidueDefinition) -> ResidueMatch:
     counter = iter(range(len(cys_def.atoms)))
     return ResidueMatch(
         residue_definition=cys_def,
-        crosslink=None,
+        crosslink_idcs=None,
         index_to_atomdef={
             next(counter): atom for atom in cys_def.atoms if not atom.leaving
         },
@@ -323,7 +323,7 @@ def cys_match_no_leaving_deprotonated_sidechain(
     counter = iter(range(len(cys_def_deprotonated_sidechain.atoms)))
     return ResidueMatch(
         residue_definition=cys_def_deprotonated_sidechain,
-        crosslink=None,
+        crosslink_idcs=None,
         index_to_atomdef={
             next(counter): atom
             for atom in cys_def_deprotonated_sidechain.atoms
@@ -336,7 +336,7 @@ def cys_match_no_leaving_deprotonated_sidechain(
 def hoh_match(hoh_def: ResidueDefinition) -> ResidueMatch:
     return ResidueMatch(
         residue_definition=hoh_def,
-        crosslink=None,
+        crosslink_idcs=None,
         index_to_atomdef={i: atom for i, atom in enumerate(hoh_def.atoms)},
     )
 

--- a/openff/pablo/_tests/conftest.py
+++ b/openff/pablo/_tests/conftest.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -94,6 +95,37 @@ def cys_data(cys_pdblines: list[str]) -> PdbData:
 @pytest.fixture
 def e2_data() -> PdbData:
     return PdbData.from_file(get_test_data_path("e2_7nel.pdb"))
+
+
+@pytest.fixture
+def he_data() -> PdbData:
+    return PdbData(
+        line_no=[None],
+        model=[None],
+        serial=["1"],
+        name=["HE"],
+        alt_loc=[""],
+        res_name=["HE"],
+        chain_id=["A"],
+        res_seq=["1"],
+        i_code=[" "],
+        x=[-1.806],
+        y=[9.969],
+        z=[9.991],
+        occupancy=[1.00],
+        temp_factor=[0.00],
+        element=["He"],
+        charge=[None],
+        terminated=[False],
+        serial_to_index=defaultdict(list, {"1": [0]}),
+        conects=[set()],
+        cryst1_a=None,
+        cryst1_b=None,
+        cryst1_c=None,
+        cryst1_alpha=None,
+        cryst1_beta=None,
+        cryst1_gamma=None,
+    )
 
 
 @pytest.fixture

--- a/openff/pablo/_tests/data/prepared_pdbs/polyglycines.pdb
+++ b/openff/pablo/_tests/data/prepared_pdbs/polyglycines.pdb
@@ -1,0 +1,465 @@
+REMARK   1 CREATED WITH OPENMM 8.3, 2025-07-26
+CRYST1   20.835   20.835   20.835  60.00  60.00  90.00 P 1           1 
+ATOM      1  N   GLY A   1       7.341   2.356   3.392  1.00  0.00           N  
+ATOM      2  H   GLY A   1       7.627   3.312   3.718  1.00  0.00           H  
+ATOM      3  CA  GLY A   1       7.516   2.347   1.949  1.00  0.00           C  
+ATOM      4  HA1 GLY A   1       8.439   2.929   1.738  1.00  0.00           H  
+ATOM      5  HA2 GLY A   1       7.729   1.293   1.661  1.00  0.00           H  
+ATOM      6  C   GLY A   1       6.355   2.899   1.216  1.00  0.00           C  
+ATOM      7  O   GLY A   1       6.349   2.964  -0.058  1.00  0.00           O  
+ATOM      8  N   GLY A   2       5.181   3.391   1.857  1.00  0.00           N  
+ATOM      9  H   GLY A   2       5.124   3.366   2.904  1.00  0.00           H  
+ATOM     10  CA  GLY A   2       4.120   3.904   1.015  1.00  0.00           C  
+ATOM     11  HA1 GLY A   2       3.779   3.133   0.287  1.00  0.00           H  
+ATOM     12  HA2 GLY A   2       4.566   4.715   0.402  1.00  0.00           H  
+ATOM     13  C   GLY A   2       2.970   4.378   1.803  1.00  0.00           C  
+ATOM     14  O   GLY A   2       3.014   4.297   3.061  1.00  0.00           O  
+ATOM     15  N   GLY A   3       1.855   4.908   1.095  1.00  0.00           N  
+ATOM     16  H   GLY A   3       1.880   4.948   0.035  1.00  0.00           H  
+ATOM     17  CA  GLY A   3       0.717   5.377   1.854  1.00  0.00           C  
+ATOM     18  HA1 GLY A   3      -0.049   5.723   1.124  1.00  0.00           H  
+ATOM     19  HA2 GLY A   3       1.046   6.222   2.510  1.00  0.00           H  
+ATOM     20  C   GLY A   3       0.126   4.287   2.674  1.00  0.00           C  
+ATOM     21  O   GLY A   3       0.631   3.197   2.706  1.00  0.00           O  
+ATOM     23  N   GLY B   1      16.973   5.042   7.439  1.00  0.00           N  
+ATOM     24  H   GLY B   1      15.999   5.321   7.715  1.00  0.00           H  
+ATOM     25  CA  GLY B   1      17.869   5.964   8.115  1.00  0.00           C  
+ATOM     26  HA1 GLY B   1      17.436   6.148   9.122  1.00  0.00           H  
+ATOM     27  HA2 GLY B   1      18.826   5.417   8.274  1.00  0.00           H  
+ATOM     28  C   GLY B   1      18.069   7.231   7.378  1.00  0.00           C  
+ATOM     29  O   GLY B   1      18.828   8.148   7.837  1.00  0.00           O  
+ATOM     30  N   GLY B   2      17.447   7.522   6.130  1.00  0.00           N  
+ATOM     31  H   GLY B   2      16.811   6.807   5.699  1.00  0.00           H  
+ATOM     32  CA  GLY B   2      17.733   8.803   5.519  1.00  0.00           C  
+ATOM     33  HA1 GLY B   2      18.827   8.936   5.361  1.00  0.00           H  
+ATOM     34  HA2 GLY B   2      17.442   9.579   6.258  1.00  0.00           H  
+ATOM     35  C   GLY B   2      17.028   8.974   4.237  1.00  0.00           C  
+ATOM     36  O   GLY B   2      16.286   8.043   3.817  1.00  0.00           O  
+ATOM     37  N   GLY B   3      17.222  10.193   3.530  1.00  0.00           N  
+ATOM     38  H   GLY B   3      17.860  10.937   3.938  1.00  0.00           H  
+ATOM     39  CA  GLY B   3      16.537  10.376   2.270  1.00  0.00           C  
+ATOM     40  HA1 GLY B   3      16.839  11.369   1.868  1.00  0.00           H  
+ATOM     41  HA2 GLY B   3      15.433  10.343   2.453  1.00  0.00           H  
+ATOM     42  C   GLY B   3      16.928   9.333   1.285  1.00  0.00           C  
+ATOM     43  O   GLY B   3      17.671   8.440   1.595  1.00  0.00           O  
+TER      44      GLY B   3
+ATOM     45  N   GLY B   1       8.570  13.486   9.225  1.00  0.00           N  
+ATOM     46  H   GLY B   1       7.973  14.305   8.951  1.00  0.00           H  
+ATOM     47  CA  GLY B   1       9.702  14.032   9.955  1.00  0.00           C  
+ATOM     48  HA1 GLY B   1       9.309  14.869  10.571  1.00  0.00           H  
+ATOM     49  HA2 GLY B   1      10.034  13.241  10.664  1.00  0.00           H  
+ATOM     50  C   GLY B   1      10.802  14.486   9.075  1.00  0.00           C  
+ATOM     51  O   GLY B   1      11.868  14.992   9.559  1.00  0.00           O  
+ATOM     52  N   GLY B   2      10.759  14.398   7.653  1.00  0.00           N  
+ATOM     53  H   GLY B   2       9.908  13.991   7.193  1.00  0.00           H  
+ATOM     54  CA  GLY B   2      11.908  14.880   6.915  1.00  0.00           C  
+ATOM     55  HA1 GLY B   2      12.837  14.354   7.233  1.00  0.00           H  
+ATOM     56  HA2 GLY B   2      12.050  15.941   7.208  1.00  0.00           H  
+ATOM     57  C   GLY B   2      11.733  14.730   5.461  1.00  0.00           C  
+ATOM     58  O   GLY B   2      10.663  14.225   5.021  1.00  0.00           O  
+ATOM     59  N   GLY B   3      12.792  15.167   4.617  1.00  0.00           N  
+ATOM     60  H   GLY B   3      13.667  15.583   5.050  1.00  0.00           H  
+ATOM     61  CA  GLY B   3      12.635  15.026   3.186  1.00  0.00           C  
+ATOM     62  HA1 GLY B   3      13.573  15.395   2.712  1.00  0.00           H  
+ATOM     63  HA2 GLY B   3      11.759  15.640   2.858  1.00  0.00           H  
+ATOM     64  C   GLY B   3      12.443  13.603   2.799  1.00  0.00           C  
+ATOM     65  O   GLY B   3      12.365  12.743   3.635  1.00  0.00           O  
+HETATM   67  O   HOH B   1       2.567  17.568   0.796  1.00  0.00           O  
+HETATM   68  H1  HOH B   1       2.065  17.427   1.625  1.00  0.00           H  
+HETATM   69  H2  HOH B   1       2.005  17.437   0.001  1.00  0.00           H  
+HETATM   71  O   HOH B   1       2.452   0.042   0.001  1.00  0.00           O  
+HETATM   72  H1  HOH B   1       1.788   0.003   0.720  1.00  0.00           H  
+HETATM   73  H2  HOH B   1       3.368   0.091   0.352  1.00  0.00           H  
+HETATM   75  O   HOH C   1       0.427  15.446   0.529  1.00  0.00           O  
+HETATM   76  H1  HOH C   1       0.143  14.610   0.106  1.00  0.00           H  
+HETATM   77  H2  HOH C   1       0.166  16.231   0.000  1.00  0.00           H  
+TER      78      HOH C   1
+HETATM   79  O   HOH X   1      15.002   7.356   8.945  1.00  0.00           O  
+HETATM   80  H1  HOH X   1      15.822   7.613   9.414  1.00  0.00           H  
+HETATM   81  H2  HOH X   1      14.727   6.439   9.163  1.00  0.00           H  
+TER      82      HOH X   1
+HETATM   83  O   HOH X   1      12.743  12.552   0.889  1.00  0.00           O  
+HETATM   84  H1  HOH X   1      12.820  13.489   0.615  1.00  0.00           H  
+HETATM   85  H2  HOH X   1      11.815  12.304   1.089  1.00  0.00           H  
+TER      86      HOH X   1
+HETATM   87  O   HOH X   1      17.321   7.368  11.312  1.00  0.00           O  
+HETATM   88  H1  HOH X   1      17.833   6.535  11.249  1.00  0.00           H  
+HETATM   89  H2  HOH X   1      17.857   8.100  11.688  1.00  0.00           H  
+TER      90      HOH X   1
+HETATM   91  O   HOH X   1       6.460   8.386   6.645  1.00  0.00           O  
+HETATM   92  H1  HOH X   1       6.634   7.708   7.329  1.00  0.00           H  
+HETATM   93  H2  HOH X   1       7.229   8.981   6.514  1.00  0.00           H  
+TER      94      HOH X   1
+HETATM   95  O   HOH X   1      10.629  10.757  11.285  1.00  0.00           O  
+HETATM   96  H1  HOH X   1       9.718  11.109  11.363  1.00  0.00           H  
+HETATM   97  H2  HOH X   1      11.285  11.470  11.130  1.00  0.00           H  
+TER      98      HOH X   1
+HETATM   99  O   HOH X   1       8.859  16.203   8.277  1.00  0.00           O  
+HETATM  100  H1  HOH X   1       8.624  15.761   7.435  1.00  0.00           H  
+HETATM  101  H2  HOH X   1       8.352  17.034   8.408  1.00  0.00           H  
+TER     102      HOH X   1
+HETATM  103  O   HOH X   1       8.840   3.885  11.221  1.00  0.00           O  
+HETATM  104  H1  HOH X   1       9.145   2.954  11.223  1.00  0.00           H  
+HETATM  105  H2  HOH X   1       9.591   4.517  11.220  1.00  0.00           H  
+TER     106      HOH X   1
+HETATM  107  O   HOH X   1       1.622  10.543   5.838  1.00  0.00           O  
+HETATM  108  H1  HOH X   1       1.804   9.630   6.143  1.00  0.00           H  
+HETATM  109  H2  HOH X   1       2.146  11.207   6.335  1.00  0.00           H  
+TER     110      HOH X   1
+HETATM  111  O   HOH X   1       9.224  18.384  10.718  1.00  0.00           O  
+HETATM  112  H1  HOH X   1       8.843  18.835  11.500  1.00  0.00           H  
+HETATM  113  H2  HOH X   1       9.632  17.523  10.955  1.00  0.00           H  
+TER     114      HOH X   1
+HETATM  115  O   HOH X   1      12.980   8.813   8.774  1.00  0.00           O  
+HETATM  116  H1  HOH X   1      13.171   8.179   8.053  1.00  0.00           H  
+HETATM  117  H2  HOH X   1      12.727   9.697   8.428  1.00  0.00           H  
+TER     118      HOH X   1
+HETATM  119  O   HOH X   1       9.443   9.258   7.522  1.00  0.00           O  
+HETATM  120  H1  HOH X   1       8.765   8.905   8.134  1.00  0.00           H  
+HETATM  121  H2  HOH X   1      10.179   8.622   7.384  1.00  0.00           H  
+TER     122      HOH X   1
+HETATM  123  O   HOH X   1       3.318   3.184   7.613  1.00  0.00           O  
+HETATM  124  H1  HOH X   1       4.278   3.264   7.792  1.00  0.00           H  
+HETATM  125  H2  HOH X   1       2.862   4.051   7.672  1.00  0.00           H  
+TER     126      HOH X   1
+HETATM  127  O   HOH X   1       7.838  -0.055   3.373  1.00  0.00           O  
+HETATM  128  H1  HOH X   1       8.584   0.549   3.572  1.00  0.00           H  
+HETATM  129  H2  HOH X   1       7.014   0.220   3.830  1.00  0.00           H  
+TER     130      HOH X   1
+HETATM  131  O   HOH X   1       6.273   3.043   5.837  1.00  0.00           O  
+HETATM  132  H1  HOH X   1       6.830   3.837   5.700  1.00  0.00           H  
+HETATM  133  H2  HOH X   1       5.319   3.269   5.887  1.00  0.00           H  
+TER     134      HOH X   1
+HETATM  135  O   HOH X   1       0.257   9.745   8.582  1.00  0.00           O  
+HETATM  136  H1  HOH X   1       0.048  10.466   7.953  1.00  0.00           H  
+HETATM  137  H2  HOH X   1       1.203   9.750   8.843  1.00  0.00           H  
+TER     138      HOH X   1
+HETATM  139  O   HOH X   1       4.996  13.789   5.869  1.00  0.00           O  
+HETATM  140  H1  HOH X   1       4.547  12.922   5.947  1.00  0.00           H  
+HETATM  141  H2  HOH X   1       5.973  13.701   5.908  1.00  0.00           H  
+TER     142      HOH X   1
+HETATM  143  O   HOH X   1       0.888  11.434   0.197  1.00  0.00           O  
+HETATM  144  H1  HOH X   1       0.006  11.013   0.258  1.00  0.00           H  
+HETATM  145  H2  HOH X   1       0.828  12.414   0.213  1.00  0.00           H  
+TER     146      HOH X   1
+HETATM  147  O   HOH X   1       1.354  11.588  12.697  1.00  0.00           O  
+HETATM  148  H1  HOH X   1       0.518  12.097  12.723  1.00  0.00           H  
+HETATM  149  H2  HOH X   1       2.141  12.175  12.708  1.00  0.00           H  
+TER     150      HOH X   1
+HETATM  151  O   HOH X   1       1.462   6.661   5.659  1.00  0.00           O  
+HETATM  152  H1  HOH X   1       2.180   6.025   5.857  1.00  0.00           H  
+HETATM  153  H2  HOH X   1       0.591   6.216   5.573  1.00  0.00           H  
+TER     154      HOH X   1
+HETATM  155  O   HOH X   1      14.712  10.560   0.267  1.00  0.00           O  
+HETATM  156  H1  HOH X   1      14.917   9.618   0.443  1.00  0.00           H  
+HETATM  157  H2  HOH X   1      13.746  10.718   0.199  1.00  0.00           H  
+TER     158      HOH X   1
+HETATM  159  O   HOH X   1       5.922  16.516  10.511  1.00  0.00           O  
+HETATM  160  H1  HOH X   1       5.403  15.716  10.732  1.00  0.00           H  
+HETATM  161  H2  HOH X   1       5.393  17.337  10.617  1.00  0.00           H  
+TER     162      HOH X   1
+HETATM  163  O   HOH X   1      15.583  13.390   6.980  1.00  0.00           O  
+HETATM  164  H1  HOH X   1      15.025  12.591   7.079  1.00  0.00           H  
+HETATM  165  H2  HOH X   1      15.057  14.216   7.060  1.00  0.00           H  
+TER     166      HOH X   1
+HETATM  167  O   HOH X   1       9.588  15.849   2.588  1.00  0.00           O  
+HETATM  168  H1  HOH X   1       9.958  16.526   1.984  1.00  0.00           H  
+HETATM  169  H2  HOH X   1       9.679  16.110   3.530  1.00  0.00           H  
+TER     170      HOH X   1
+HETATM  171  O   HOH X   1       0.400  14.877   5.523  1.00  0.00           O  
+HETATM  172  H1  HOH X   1       0.557  14.592   4.600  1.00  0.00           H  
+HETATM  173  H2  HOH X   1       1.195  14.749   6.086  1.00  0.00           H  
+TER     174      HOH X   1
+HETATM  175  O   HOH X   1       7.602  15.387   1.653  1.00  0.00           O  
+HETATM  176  H1  HOH X   1       7.210  14.898   0.900  1.00  0.00           H  
+HETATM  177  H2  HOH X   1       7.630  14.842   2.469  1.00  0.00           H  
+TER     178      HOH X   1
+HETATM  179  O   HOH X   1      12.073   7.892   6.169  1.00  0.00           O  
+HETATM  180  H1  HOH X   1      11.529   7.113   6.408  1.00  0.00           H  
+HETATM  181  H2  HOH X   1      11.650   8.433   5.466  1.00  0.00           H  
+TER     182      HOH X   1
+HETATM  183  O   HOH X   1      11.135   3.959   5.454  1.00  0.00           O  
+HETATM  184  H1  HOH X   1      11.502   4.816   5.756  1.00  0.00           H  
+HETATM  185  H2  HOH X   1      11.818   3.254   5.435  1.00  0.00           H  
+TER     186      HOH X   1
+HETATM  187  O   HOH X   1       5.671   9.259  12.719  1.00  0.00           O  
+HETATM  188  H1  HOH X   1       6.271  10.029  12.635  1.00  0.00           H  
+HETATM  189  H2  HOH X   1       4.898   9.329  12.118  1.00  0.00           H  
+TER     190      HOH X   1
+HETATM  191  O   HOH X   1       3.314   3.678  12.122  1.00  0.00           O  
+HETATM  192  H1  HOH X   1       4.203   3.791  11.728  1.00  0.00           H  
+HETATM  193  H2  HOH X   1       2.954   2.779  11.963  1.00  0.00           H  
+TER     194      HOH X   1
+HETATM  195  O   HOH X   1       6.120  12.815   2.933  1.00  0.00           O  
+HETATM  196  H1  HOH X   1       5.497  12.059   2.912  1.00  0.00           H  
+HETATM  197  H2  HOH X   1       5.934  13.462   2.219  1.00  0.00           H  
+TER     198      HOH X   1
+HETATM  199  O   HOH X   1       4.330   1.629   4.079  1.00  0.00           O  
+HETATM  200  H1  HOH X   1       3.978   0.727   4.226  1.00  0.00           H  
+HETATM  201  H2  HOH X   1       5.276   1.699   4.330  1.00  0.00           H  
+TER     202      HOH X   1
+HETATM  203  O   HOH X   1       3.796   9.880   2.378  1.00  0.00           O  
+HETATM  204  H1  HOH X   1       4.586   9.304   2.422  1.00  0.00           H  
+HETATM  205  H2  HOH X   1       2.970   9.361   2.268  1.00  0.00           H  
+TER     206      HOH X   1
+HETATM  207  O   HOH X   1       3.236   6.563   1.807  1.00  0.00           O  
+HETATM  208  H1  HOH X   1       2.740   7.330   1.454  1.00  0.00           H  
+HETATM  209  H2  HOH X   1       4.186   6.597   1.562  1.00  0.00           H  
+TER     210      HOH X   1
+HETATM  211  O   HOH X   1       5.089   6.069   6.491  1.00  0.00           O  
+HETATM  212  H1  HOH X   1       4.562   5.243   6.491  1.00  0.00           H  
+HETATM  213  H2  HOH X   1       4.648   6.786   6.996  1.00  0.00           H  
+TER     214      HOH X   1
+HETATM  215  O   HOH X   1      18.804  14.161   5.079  1.00  0.00           O  
+HETATM  216  H1  HOH X   1      18.050  14.750   4.871  1.00  0.00           H  
+HETATM  217  H2  HOH X   1      18.833  13.379   4.487  1.00  0.00           H  
+TER     218      HOH X   1
+HETATM  219  O   HOH X   1       5.769  10.080   8.453  1.00  0.00           O  
+HETATM  220  H1  HOH X   1       6.555  10.571   8.135  1.00  0.00           H  
+HETATM  221  H2  HOH X   1       5.116  10.674   8.883  1.00  0.00           H  
+TER     222      HOH X   1
+HETATM  223  O   HOH X   1      16.234  13.001  10.589  1.00  0.00           O  
+HETATM  224  H1  HOH X   1      15.477  12.650  11.102  1.00  0.00           H  
+HETATM  225  H2  HOH X   1      16.113  13.949  10.361  1.00  0.00           H  
+TER     226      HOH X   1
+HETATM  227  O   HOH X   1      17.526  12.352   5.947  1.00  0.00           O  
+HETATM  228  H1  HOH X   1      16.893  12.762   5.322  1.00  0.00           H  
+HETATM  229  H2  HOH X   1      17.732  12.946   6.701  1.00  0.00           H  
+TER     230      HOH X   1
+HETATM  231  O   HOH X   1       9.216  11.524   6.921  1.00  0.00           O  
+HETATM  232  H1  HOH X   1       9.749  11.493   6.100  1.00  0.00           H  
+HETATM  233  H2  HOH X   1       8.378  12.020   6.795  1.00  0.00           H  
+TER     234      HOH X   1
+HETATM  235  O   HOH X   1      12.773   2.584  10.637  1.00  0.00           O  
+HETATM  236  H1  HOH X   1      12.801   1.726  10.165  1.00  0.00           H  
+HETATM  237  H2  HOH X   1      11.856   2.927  10.719  1.00  0.00           H  
+TER     238      HOH X   1
+HETATM  239  O   HOH X   1       7.546  13.297  12.732  1.00  0.00           O  
+HETATM  240  H1  HOH X   1       7.231  14.169  12.416  1.00  0.00           H  
+HETATM  241  H2  HOH X   1       8.489  13.144  12.504  1.00  0.00           H  
+TER     242      HOH X   1
+HETATM  243  O   HOH X   1       4.446   6.192  12.093  1.00  0.00           O  
+HETATM  244  H1  HOH X   1       4.372   5.982  11.139  1.00  0.00           H  
+HETATM  245  H2  HOH X   1       4.865   7.067  12.244  1.00  0.00           H  
+TER     246      HOH X   1
+HETATM  247  O   HOH X   1      15.619   3.649   5.950  1.00  0.00           O  
+HETATM  248  H1  HOH X   1      15.362   4.571   5.746  1.00  0.00           H  
+HETATM  249  H2  HOH X   1      16.591   3.518   5.892  1.00  0.00           H  
+TER     250      HOH X   1
+HETATM  251  O   HOH X   1      18.023   1.198   2.926  1.00  0.00           O  
+HETATM  252  H1  HOH X   1      17.472   0.409   3.105  1.00  0.00           H  
+HETATM  253  H2  HOH X   1      17.886   1.901   3.598  1.00  0.00           H  
+TER     254      HOH X   1
+HETATM  255  O   HOH X   1       1.625  17.218  11.391  1.00  0.00           O  
+HETATM  256  H1  HOH X   1       1.517  17.779  12.187  1.00  0.00           H  
+HETATM  257  H2  HOH X   1       1.017  17.486  10.669  1.00  0.00           H  
+TER     258      HOH X   1
+HETATM  259  O   HOH X   1      12.921   5.080  12.446  1.00  0.00           O  
+HETATM  260  H1  HOH X   1      13.510   4.302  12.357  1.00  0.00           H  
+HETATM  261  H2  HOH X   1      12.536   5.348  11.583  1.00  0.00           H  
+TER     262      HOH X   1
+HETATM  263  O   HOH X   1      12.743  12.597  12.446  1.00  0.00           O  
+HETATM  264  H1  HOH X   1      13.540  12.094  12.712  1.00  0.00           H  
+HETATM  265  H2  HOH X   1      12.898  13.566  12.467  1.00  0.00           H  
+TER     266      HOH X   1
+HETATM  267  O   HOH X   1      11.759  12.468   8.523  1.00  0.00           O  
+HETATM  268  H1  HOH X   1      12.498  12.059   8.026  1.00  0.00           H  
+HETATM  269  H2  HOH X   1      10.973  11.882   8.559  1.00  0.00           H  
+TER     270      HOH X   1
+HETATM  271  O   HOH X   1       4.309  14.738   1.459  1.00  0.00           O  
+HETATM  272  H1  HOH X   1       3.617  14.312   0.913  1.00  0.00           H  
+HETATM  273  H2  HOH X   1       4.082  15.667   1.681  1.00  0.00           H  
+TER     274      HOH X   1
+HETATM  275  O   HOH X   1       7.495   0.912   6.150  1.00  0.00           O  
+HETATM  276  H1  HOH X   1       8.001   1.446   5.504  1.00  0.00           H  
+HETATM  277  H2  HOH X   1       6.549   0.833   5.899  1.00  0.00           H  
+TER     278      HOH X   1
+HETATM  279  O   HOH X   1       0.631   9.775  11.201  1.00  0.00           O  
+HETATM  280  H1  HOH X   1       0.086   9.922  12.001  1.00  0.00           H  
+HETATM  281  H2  HOH X   1       0.489   8.882  10.819  1.00  0.00           H  
+TER     282      HOH X   1
+HETATM  283  O   HOH X   1      11.932  18.584   3.633  1.00  0.00           O  
+HETATM  284  H1  HOH X   1      10.976  18.795   3.596  1.00  0.00           H  
+HETATM  285  H2  HOH X   1      12.090  17.636   3.835  1.00  0.00           H  
+TER     286      HOH X   1
+HETATM  287  O   HOH X   1       2.235   0.783   8.852  1.00  0.00           O  
+HETATM  288  H1  HOH X   1       2.703   0.423   8.071  1.00  0.00           H  
+HETATM  289  H2  HOH X   1       1.517   1.402   8.596  1.00  0.00           H  
+TER     290      HOH X   1
+HETATM  291  O   HOH X   1       2.254  15.548   8.990  1.00  0.00           O  
+HETATM  292  H1  HOH X   1       2.230  16.183   8.246  1.00  0.00           H  
+HETATM  293  H2  HOH X   1       3.168  15.398   9.315  1.00  0.00           H  
+TER     294      HOH X   1
+HETATM  295  O   HOH X   1      12.676  18.250   6.447  1.00  0.00           O  
+HETATM  296  H1  HOH X   1      12.974  18.402   7.367  1.00  0.00           H  
+HETATM  297  H2  HOH X   1      13.145  17.495   6.030  1.00  0.00           H  
+TER     298      HOH X   1
+HETATM  299  O   HOH X   1       1.193   3.446   5.271  1.00  0.00           O  
+HETATM  300  H1  HOH X   1       0.734   4.163   4.786  1.00  0.00           H  
+HETATM  301  H2  HOH X   1       2.168   3.499   5.166  1.00  0.00           H  
+TER     302      HOH X   1
+HETATM  303  O   HOH X   1       9.307  18.062   0.550  1.00  0.00           O  
+HETATM  304  H1  HOH X   1       9.088  17.282   0.000  1.00  0.00           H  
+HETATM  305  H2  HOH X   1       9.573  18.833   0.003  1.00  0.00           H  
+TER     306      HOH X   1
+HETATM  307  O   HOH X   1       6.495   1.490  10.576  1.00  0.00           O  
+HETATM  308  H1  HOH X   1       5.560   1.775  10.503  1.00  0.00           H  
+HETATM  309  H2  HOH X   1       7.083   2.230  10.840  1.00  0.00           H  
+TER     310      HOH X   1
+HETATM  311  O   HOH X   1      11.149   0.979  11.464  1.00  0.00           O  
+HETATM  312  H1  HOH X   1      11.645   0.149  11.312  1.00  0.00           H  
+HETATM  313  H2  HOH X   1      10.233   0.808  11.772  1.00  0.00           H  
+TER     314      HOH X   1
+HETATM  315  O   HOH X   1      13.818   7.582  11.913  1.00  0.00           O  
+HETATM  316  H1  HOH X   1      13.920   7.050  12.729  1.00  0.00           H  
+HETATM  317  H2  HOH X   1      14.376   7.240  11.181  1.00  0.00           H  
+TER     318      HOH X   1
+HETATM  319  O   HOH X   1       7.078   6.873   3.745  1.00  0.00           O  
+HETATM  320  H1  HOH X   1       6.831   7.553   4.405  1.00  0.00           H  
+HETATM  321  H2  HOH X   1       6.437   6.129   3.729  1.00  0.00           H  
+TER     322      HOH X   1
+HETATM  323  O   HOH X   1       5.929   7.376   0.005  1.00  0.00           O  
+HETATM  324  H1  HOH X   1       6.693   7.988   0.025  1.00  0.00           H  
+HETATM  325  H2  HOH X   1       5.073   7.857  -0.009  1.00  0.00           H  
+TER     326      HOH X   1
+HETATM  327  O   HOH X   1      12.931  16.661   0.635  1.00  0.00           O  
+HETATM  328  H1  HOH X   1      13.654  16.844   0.001  1.00  0.00           H  
+HETATM  329  H2  HOH X   1      13.031  17.178   1.464  1.00  0.00           H  
+TER     330      HOH X   1
+HETATM  331  O   HOH X   1      14.816  10.357   6.584  1.00  0.00           O  
+HETATM  332  H1  HOH X   1      15.565  10.714   6.064  1.00  0.00           H  
+HETATM  333  H2  HOH X   1      15.066  10.190   7.519  1.00  0.00           H  
+TER     334      HOH X   1
+HETATM  335  O   HOH X   1       9.517  12.888   0.002  1.00  0.00           O  
+HETATM  336  H1  HOH X   1       9.361  12.009   0.403  1.00  0.00           H  
+HETATM  337  H2  HOH X   1      10.020  13.481   0.602  1.00  0.00           H  
+TER     338      HOH X   1
+HETATM  339  O   HOH X   1      16.921  17.735   0.719  1.00  0.00           O  
+HETATM  340  H1  HOH X   1      16.069  17.839   1.191  1.00  0.00           H  
+HETATM  341  H2  HOH X   1      17.157  18.539   0.208  1.00  0.00           H  
+TER     342      HOH X   1
+HETATM  343  O   HOH X   1       3.198  12.006   1.978  1.00  0.00           O  
+HETATM  344  H1  HOH X   1       3.869  12.054   1.267  1.00  0.00           H  
+HETATM  345  H2  HOH X   1       2.426  12.584   1.794  1.00  0.00           H  
+TER     346      HOH X   1
+HETATM  347  O   HOH X   1      16.607  16.279   2.903  1.00  0.00           O  
+HETATM  348  H1  HOH X   1      17.152  15.465   2.889  1.00  0.00           H  
+HETATM  349  H2  HOH X   1      15.660  16.089   2.728  1.00  0.00           H  
+TER     350      HOH X   1
+HETATM  351  O   HOH X   1       5.909  12.479  10.819  1.00  0.00           O  
+HETATM  352  H1  HOH X   1       6.394  11.819  11.356  1.00  0.00           H  
+HETATM  353  H2  HOH X   1       6.511  13.152  10.434  1.00  0.00           H  
+TER     354      HOH X   1
+HETATM  355  O   HOH X   1       4.390  16.383   6.272  1.00  0.00           O  
+HETATM  356  H1  HOH X   1       5.150  16.259   6.877  1.00  0.00           H  
+HETATM  357  H2  HOH X   1       3.615  15.844   6.541  1.00  0.00           H  
+TER     358      HOH X   1
+HETATM  359  O   HOH X   1       4.369  17.980   3.762  1.00  0.00           O  
+HETATM  360  H1  HOH X   1       5.223  18.353   4.063  1.00  0.00           H  
+HETATM  361  H2  HOH X   1       4.439  17.022   3.558  1.00  0.00           H  
+TER     362      HOH X   1
+HETATM  363  O   HOH X   1       9.089   1.436   7.574  1.00  0.00           O  
+HETATM  364  H1  HOH X   1       9.103   2.393   7.364  1.00  0.00           H  
+HETATM  365  H2  HOH X   1       9.994   1.075   7.696  1.00  0.00           H  
+TER     366      HOH X   1
+HETATM  367  O   HOH X   1       6.533   4.954  12.394  1.00  0.00           O  
+HETATM  368  H1  HOH X   1       7.373   5.388  12.652  1.00  0.00           H  
+HETATM  369  H2  HOH X   1       6.655   3.997  12.216  1.00  0.00           H  
+TER     370      HOH X   1
+HETATM  371  O   HOH X   1      13.586  12.658   9.861  1.00  0.00           O  
+HETATM  372  H1  HOH X   1      14.213  13.257   9.406  1.00  0.00           H  
+HETATM  373  H2  HOH X   1      12.860  13.153  10.300  1.00  0.00           H  
+TER     374      HOH X   1
+HETATM  375  O   HOH X   1       1.120   7.757  12.694  1.00  0.00           O  
+HETATM  376  H1  HOH X   1       0.295   7.230  12.729  1.00  0.00           H  
+HETATM  377  H2  HOH X   1       1.845   7.271  12.245  1.00  0.00           H  
+TER     378      HOH X   1
+HETATM  379  O   HOH X   1      13.863   3.399   4.643  1.00  0.00           O  
+HETATM  380  H1  HOH X   1      13.978   2.446   4.834  1.00  0.00           H  
+HETATM  381  H2  HOH X   1      13.540   3.553   3.729  1.00  0.00           H  
+TER     382      HOH X   1
+HETATM  383  O   HOH X   1       3.389   8.202   9.414  1.00  0.00           O  
+HETATM  384  H1  HOH X   1       3.542   7.235   9.395  1.00  0.00           H  
+HETATM  385  H2  HOH X   1       4.142   8.699   9.027  1.00  0.00           H  
+TER     386      HOH X   1
+HETATM  387  O   HOH X   1      14.441  13.642   3.720  1.00  0.00           O  
+HETATM  388  H1  HOH X   1      14.657  12.782   3.305  1.00  0.00           H  
+HETATM  389  H2  HOH X   1      15.152  13.946   4.324  1.00  0.00           H  
+TER     390      HOH X   1
+HETATM  391  O   HOH X   1      11.362   3.773   8.535  1.00  0.00           O  
+HETATM  392  H1  HOH X   1      11.087   2.943   8.094  1.00  0.00           H  
+HETATM  393  H2  HOH X   1      10.699   4.488   8.418  1.00  0.00           H  
+TER     394      HOH X   1
+HETATM  395  O   HOH X   1       6.362   5.152   8.750  1.00  0.00           O  
+HETATM  396  H1  HOH X   1       6.818   6.019   8.779  1.00  0.00           H  
+HETATM  397  H2  HOH X   1       5.386   5.251   8.777  1.00  0.00           H  
+TER     398      HOH X   1
+HETATM  399  O   HOH X   1       6.736  17.374   2.053  1.00  0.00           O  
+HETATM  400  H1  HOH X   1       7.640  17.736   1.947  1.00  0.00           H  
+HETATM  401  H2  HOH X   1       6.150  17.628   1.308  1.00  0.00           H  
+TER     402      HOH X   1
+HETATM  403  O   HOH X   1      14.085   3.874   9.130  1.00  0.00           O  
+HETATM  404  H1  HOH X   1      14.651   3.610   9.884  1.00  0.00           H  
+HETATM  405  H2  HOH X   1      14.014   3.162   8.458  1.00  0.00           H  
+TER     406      HOH X   1
+HETATM  407  O   HOH X   1       4.898  14.052   9.122  1.00  0.00           O  
+HETATM  408  H1  HOH X   1       4.931  13.122   8.817  1.00  0.00           H  
+HETATM  409  H2  HOH X   1       5.265  14.670   8.453  1.00  0.00           H  
+TER     410      HOH X   1
+HETATM  411  O   HOH X   1      14.318   6.469   6.192  1.00  0.00           O  
+HETATM  412  H1  HOH X   1      14.645   6.745   5.312  1.00  0.00           H  
+HETATM  413  H2  HOH X   1      13.468   5.982   6.131  1.00  0.00           H  
+TER     414      HOH X   1
+HETATM  415  O   HOH X   1      10.416   5.302   1.957  1.00  0.00           O  
+HETATM  416  H1  HOH X   1       9.896   5.837   1.323  1.00  0.00           H  
+HETATM  417  H2  HOH X   1       9.995   4.434   2.137  1.00  0.00           H  
+TER     418      HOH X   1
+HETATM  419  O   HOH X   1      10.762  18.654   8.072  1.00  0.00           O  
+HETATM  420  H1  HOH X   1      10.735  17.840   8.616  1.00  0.00           H  
+HETATM  421  H2  HOH X   1       9.899  18.834   7.638  1.00  0.00           H  
+TER     422      HOH X   1
+HETATM  423  O   HOH X   1       7.085  10.999   4.940  1.00  0.00           O  
+HETATM  424  H1  HOH X   1       7.909  10.473   4.992  1.00  0.00           H  
+HETATM  425  H2  HOH X   1       6.294  10.430   4.820  1.00  0.00           H  
+TER     426      HOH X   1
+HETATM  427  O   HOH X   1      18.787   2.788   0.455  1.00  0.00           O  
+HETATM  428  H1  HOH X   1      18.782   2.632   1.422  1.00  0.00           H  
+HETATM  429  H2  HOH X   1      17.983   2.427   0.021  1.00  0.00           H  
+TER     430      HOH X   1
+HETATM  431  O   HOH X   1      12.840   0.414   2.125  1.00  0.00           O  
+HETATM  432  H1  HOH X   1      13.613   1.002   1.998  1.00  0.00           H  
+HETATM  433  H2  HOH X   1      12.787   0.072   3.044  1.00  0.00           H  
+TER     434      HOH X   1
+HETATM  435  O   HOH X   1      18.170   2.686   9.261  1.00  0.00           O  
+HETATM  436  H1  HOH X   1      18.278   3.640   9.453  1.00  0.00           H  
+HETATM  437  H2  HOH X   1      18.542   2.445   8.384  1.00  0.00           H  
+TER     438      HOH X   1
+HETATM  439  O   HOH X   1      13.106  11.005   5.354  1.00  0.00           O  
+HETATM  440  H1  HOH X   1      13.505  10.955   4.461  1.00  0.00           H  
+HETATM  441  H2  HOH X   1      13.367  11.825   5.826  1.00  0.00           H  
+TER     442      HOH X   1
+HETATM  443  O   HOH X   1       7.887   5.759   5.476  1.00  0.00           O  
+HETATM  444  H1  HOH X   1       8.787   5.383   5.388  1.00  0.00           H  
+HETATM  445  H2  HOH X   1       7.600   5.807   6.414  1.00  0.00           H  
+TER     446      HOH X   1
+HETATM  447  O   HOH X   1       4.409   6.968   3.904  1.00  0.00           O  
+HETATM  448  H1  HOH X   1       4.234   7.491   4.713  1.00  0.00           H  
+HETATM  449  H2  HOH X   1       3.917   6.118   3.904  1.00  0.00           H  
+TER     450      HOH X   1
+HETATM  451  O   HOH X   1      15.720   2.021   2.416  1.00  0.00           O  
+HETATM  452  H1  HOH X   1      15.275   2.868   2.205  1.00  0.00           H  
+HETATM  453  H2  HOH X   1      15.549   1.738   3.340  1.00  0.00           H  
+TER     454      HOH X   1
+HETATM  455  O   HOH X   1      16.135  15.951   6.237  1.00  0.00           O  
+HETATM  456  H1  HOH X   1      15.852  15.807   5.311  1.00  0.00           H  
+HETATM  457  H2  HOH X   1      17.099  16.123   6.303  1.00  0.00           H  
+TER     458      HOH X   1
+HETATM  459  O   HOH X   1       2.473  14.159  11.120  1.00  0.00           O  
+HETATM  460  H1  HOH X   1       3.118  13.422  11.136  1.00  0.00           H  
+HETATM  461  H2  HOH X   1       1.550  13.836  11.023  1.00  0.00           H  
+TER     462      HOH X   1
+HETATM  463  O   HOH X   1      15.211  18.057   5.524  1.00  0.00           O  
+HETATM  464  H1  HOH X   1      15.799  18.047   4.741  1.00  0.00           H  
+HETATM  465  H2  HOH X   1      15.379  18.835   6.099  1.00  0.00           H  
+TER     466      HOH X   1
+END

--- a/openff/pablo/_tests/data/prepared_pdbs/polyglycines.py
+++ b/openff/pablo/_tests/data/prepared_pdbs/polyglycines.py
@@ -1,0 +1,191 @@
+"""This generates a PDB file including every kind of residue-residue interface
+understood by ``PdbData.filter_on_polymer_linkages()``:
+
+- no_polymer_new_chain (water chain B -> C)
+- no_polymer_after_ter (water chain C -> X and X -> X)
+- no_polymer_no_links (water chain C -> C)
+- continue_polymer (middle glycine residue of all triglycine molecules)
+- end_polymer_with_new_chain (triglycine chain A -> B)
+- end_polymer_with_ter (triglycine chain B -> B)
+- end_polymer_no_links (triglycine chain B -> water chain B)
+- start_polymer_with_new_chain (triglycine chain A -> B)
+- start_polymer_with_ter (triglycine chain B -> B)
+- start_polymer_no_links (triglycine chain B -> water chain B)
+
+Note that the triglycines begin and end with a negatively charged amine and a
+carboxylic carbanion so that adjacent glycine chains have the right atoms to
+form a polymer bond. For this to load, two special glycine residue definitions
+are needed:
+
+ResidueDefinition.from_smiles(
+    mapped_smiles="[N-:1]([H:2])[C:3]([H:4])([H:5])[C:6](=[O:7])[O:8][H:9]",
+    atom_names={1: "N", 2: "H", 3: "CA", 4: "HA1", 5: "HA2", 6: "C", 7: "O", 8: "OXT", 9: "HXT"},
+    residue_name="GLY",
+    leaving_atoms=(8, 9),
+    linking_bond=PEPTIDE_BOND,
+    description="GLYCINE w/ negative formal charge on N",
+)
+ResidueDefinition.from_smiles(
+    mapped_smiles="[N:1]([H:2])([H:8])[C:3]([H:4])([H:5])[C-:6]=[O:7]",
+    atom_names={1: "N", 2: "H", 3: "CA", 4: "HA1", 5: "HA2", 6: "C", 7: "O", 8: "H2"},
+    residue_name="GLY",
+    leaving_atoms=(8,),
+    linking_bond=PEPTIDE_BOND,
+    description="GLYCINE w/ negative formal charge on C",
+)
+
+"""
+
+from io import StringIO
+from pathlib import Path
+from collections.abc import Iterable
+
+from openff.toolkit import Molecule, Topology
+from openff.units import Quantity
+
+from openff.interchange.components._packmol import pack_box
+
+
+def molecule_from_smiles_and_metadata(
+    smiles: str,
+    metadata_dict: dict[Iterable[int], dict[str, str]],
+) -> Molecule:
+    molecule = Molecule.from_mapped_smiles(smiles)
+    for maps, metadata in metadata_dict.items():
+        for m in maps:
+            atom = molecule.atom(m - 1)
+            for key, value in metadata.items():
+                if key == "atom_name":
+                    atom.name = value
+                else:
+                    atom.metadata[key] = value
+
+    return molecule
+
+
+def triglycine(chain_id: str = "X", terminated: bool = True) -> Molecule:
+    return molecule_from_smiles_and_metadata(
+        smiles=(
+            "[N-:1]([H:2])[C:3]([H:4])([H:5])[C:6](=[O:7])"
+            + "[N:8]([H:9])[C:10]([H:11])([H:12])[C:13](=[O:14])"
+            + "[N:15]([H:16])[C:17]([H:18])([H:19])[C-:20](=[O:21])"
+        ),
+        metadata_dict={
+            range(1, 22): {"residue_name": "GLY", "chain_id": chain_id},
+            range(1, 8): {"residue_number": "1"},
+            range(8, 15): {"residue_number": "2"},
+            range(15, 22): {"residue_number": "3"},
+            (1, 8, 15): {"atom_name": "N"},
+            (2, 9, 16): {"atom_name": "H"},
+            (3, 10, 17): {"atom_name": "CA"},
+            (4, 11, 18): {"atom_name": "HA1"},
+            (5, 12, 19): {"atom_name": "HA2"},
+            (6, 13, 20): {"atom_name": "C"},
+            (7, 14, 21): {"atom_name": "O"},
+            (21,): {"terminated": terminated},
+        },
+    )
+
+
+def water(chain_id: str = "X", terminated: bool = True) -> Molecule:
+    return molecule_from_smiles_and_metadata(
+        smiles="[H:2][O:1][H:3]",
+        metadata_dict={
+            range(1, 4): {
+                "residue_name": "HOH",
+                "chain_id": chain_id,
+                "residue_number": "1",
+            },
+            (1,): {"atom_name": "O"},
+            (2,): {"atom_name": "H1"},
+            (3,): {
+                "atom_name": "H2",
+                "terminated": terminated,
+            },
+        },
+    )
+
+
+def write_pdb_from_metadata(filename: Path | str, topology: Topology):
+    path = Path(filename)
+    lines = []
+    for serial, (atom, xyz) in enumerate(zip(topology.atoms, topology.get_positions())):
+        name = atom.name
+        altloc = atom.metadata.get("alt_loc", " ")
+        resname = atom.metadata.get("residue_name", None)
+        resseq = atom.metadata.get("residue_number", None)
+        chainid = atom.metadata.get("chain_id", None)
+        icode = atom.metadata.get("insertion_code", " ")
+        bfac = atom.metadata.get("b_factor", "0.0")
+        occ = atom.metadata.get("occupancy", "1.0")
+        x, y, z = xyz.m_as("nm")
+        elem = atom.symbol
+
+        assert all(
+            [
+                name,
+                resname,
+                resseq,
+                chainid,
+                len(name) <= 5,
+                len(resname) <= 4,
+                len(chainid) == 1,
+                len(icode) == 1,
+                len(altloc) == 1,
+                len(elem) <= 2,
+                serial < 100000,
+                len(str(resseq)) <= 5,
+            ],
+        )
+        lines.append(
+            f"ATOM  {serial: >5} {name: >4}{altloc}{resname: <4}{chainid}"
+            + f"{resseq: >4}{icode}   {x:6.2f}{y:6.2f}{z:6.2f}{occ:1.3}"
+            + f"{bfac:1.3}          {elem: <2}",
+        )
+        if atom.metadata.get("terminated", False):
+            lines.append("TER")
+
+    path.write_text("\n".join(lines))
+
+
+def main():
+    topology: Topology = pack_box(
+        molecules=[
+            triglycine("A", terminated=False),
+            triglycine("B", terminated=True),
+            triglycine("B", terminated=False),
+            water("B", terminated=False),
+            water("B", terminated=False),
+            water("C", terminated=True),
+            water(),
+        ],
+        number_of_copies=[1, 1, 1, 1, 1, 1, 97],
+        target_density=Quantity("0.8 g/ml"),
+    )
+    # write_pdb_from_metadata(Path(__file__).with_suffix(".pdb"), topology)
+
+    with StringIO() as f:
+        topology.to_file(
+            f,
+            file_format="PDB",
+            keep_ids=True,
+            ensure_unique_atom_names=False,
+        )
+        pdbstr = f.getvalue()
+
+    atoms = iter(topology.atoms)
+    remove_ters = False
+    pdblines = []
+    for line in pdbstr.splitlines():
+        if line.startswith(("ATOM  ", "HETATM")):
+            atom = next(atoms)
+            remove_ters = not atom.metadata.get("terminated", False)
+        if line.startswith("TER   ") and remove_ters:
+            continue
+        pdblines.append(line)
+
+    Path(__file__).with_suffix(".pdb").write_text("\n".join(pdblines))
+
+
+if __name__ == "__main__":
+    main()

--- a/openff/pablo/_tests/test_ccd.py
+++ b/openff/pablo/_tests/test_ccd.py
@@ -82,6 +82,11 @@ def test_ccdcache_gives_clear_errors(resname: str, expected_message: str):
         CCD_RESIDUE_DEFINITION_CACHE[resname]
 
 
+def test_default_ccdcache_cys_definitions_unique():
+    cys_defs = CCD_RESIDUE_DEFINITION_CACHE["CYS"]
+    assert len(set(cys_defs)) == len(cys_defs)
+
+
 def test_ccdcache_with(hooh_def: ResidueDefinition, hoh_def: ResidueDefinition):
     assert "HOOH" not in CCD_RESIDUE_DEFINITION_CACHE
     new_ccdcache = CCD_RESIDUE_DEFINITION_CACHE.with_([hooh_def])

--- a/openff/pablo/_tests/test_matching.py
+++ b/openff/pablo/_tests/test_matching.py
@@ -1,0 +1,122 @@
+from collections.abc import Iterable
+
+import pytest
+
+from openff.pablo._pdb_data import ResidueMatch
+from openff.pablo.residue import ResidueDefinition
+
+
+class TestResidueMatch:
+    def test_get_atom_by_index(self, cys_match: ResidueMatch):
+        for i, atom in enumerate(cys_match.residue_definition.atoms):
+            assert cys_match.atom(i) == atom
+
+    def test_get_atom_by_name(self, cys_match: ResidueMatch):
+        for atom in cys_match.residue_definition.atoms:
+            assert cys_match.atom(atom.name) == atom
+
+    def test_get_atom_type_error(self, cys_match: ResidueMatch):
+        with pytest.raises(TypeError):
+            cys_match.atom(3.14159)  # type: ignore
+
+    def test_set_crosslink_mutates_match(self, cys_match: ResidueMatch):
+        cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["SG"], 99)
+        assert cys_match.crosslink_idcs == (
+            cys_match.canonical_atom_name_to_index["SG"],
+            99,
+        )
+
+    def test_set_crosslink_raises_on_wrong_atom(self, cys_match: ResidueMatch):
+        with pytest.raises(ValueError):
+            cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["C"], 99)
+
+    def test_prototype_index_in_match(self, cys_match: ResidueMatch):
+        assert cys_match.prototype_index in cys_match.index_to_atomdef
+
+    def test_set_crosslink_raises_on_atom1_from_other_residue(
+        self,
+        cys_match: ResidueMatch,
+    ):
+        with pytest.raises(ValueError):
+            n_matched_atoms = len(cys_match.res_atom_idcs)
+            cys_match.set_crosslink(n_matched_atoms + 1, n_matched_atoms + 2)
+
+    def test_set_crosslink_raises_on_atom2_from_this_residue(
+        self,
+        cys_match: ResidueMatch,
+    ):
+        with pytest.raises(ValueError):
+            cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["SG"], 0)
+
+    @pytest.mark.parametrize(
+        "fixture_name, missing_atoms",
+        [
+            ("cys_match", []),
+            ("cys_match_no_leaving", ["OXT", "HXT", "H2", "HG"]),
+            ("cys_match_no_leaving_deprotonated_sidechain", ["OXT", "HXT", "H2"]),
+        ],
+    )
+    def test_missing_atoms(
+        self,
+        request: pytest.FixtureRequest,
+        fixture_name: str,
+        missing_atoms: Iterable[str],
+    ):
+        match: ResidueMatch = request.getfixturevalue(fixture_name)
+        assert match.missing_atoms == set(missing_atoms)
+
+    def test_missing_leaving_atoms(
+        self,
+        hoh_def: ResidueDefinition,
+    ):
+        match = ResidueMatch(
+            residue_definition=hoh_def,
+            crosslink_idcs=None,
+            index_to_atomdef={
+                i: atom for i, atom in enumerate(hoh_def.atoms) if atom.name != "O"
+            },
+        )
+        assert match.missing_atoms == {"O"}
+        assert match.missing_leaving_atoms == set()
+
+    @pytest.mark.parametrize(
+        "expect_prop_suffix",
+        ("prior_bond", "posterior_bond", "crosslink"),
+    )
+    def test_expect_props_false_when_not_supported_by_resdef(
+        self,
+        expect_prop_suffix: str,
+        hoh_match: ResidueMatch,
+    ):
+        assert getattr(hoh_match, "expects_" + expect_prop_suffix) is False
+
+    @pytest.mark.parametrize(
+        "expect_prop_suffix",
+        ("prior_bond", "posterior_bond", "crosslink"),
+    )
+    def test_expect_props_false_when_leaving_atoms_present(
+        self,
+        expect_prop_suffix: str,
+        cys_match: ResidueMatch,
+    ):
+        assert getattr(cys_match, "expects_" + expect_prop_suffix) is False
+
+    def test_expect_props_false_when_leaving_atoms_missing_from_resdef(
+        self,
+        cys_match_no_leaving_deprotonated_sidechain: ResidueMatch,
+    ):
+        assert cys_match_no_leaving_deprotonated_sidechain.expects_crosslink is False
+
+    @pytest.mark.parametrize(
+        "expect_prop_suffix",
+        ("prior_bond", "posterior_bond", "crosslink"),
+    )
+    def test_expect_props_true_when_leaving_atoms_absent(
+        self,
+        expect_prop_suffix: str,
+        cys_match_no_leaving: ResidueMatch,
+    ):
+        assert getattr(cys_match_no_leaving, "expects_" + expect_prop_suffix) is True
+
+    def test_match_agrees_with_self(self, any_match: ResidueMatch):
+        any_match.agrees_with(any_match)

--- a/openff/pablo/_tests/test_pdb.py
+++ b/openff/pablo/_tests/test_pdb.py
@@ -1,12 +1,10 @@
 import random
 from io import StringIO
 
-import pytest
 from openff.toolkit import Molecule
 
 from openff.pablo._pdb import (
     _add_to_molecule,
-    _match_unknown_molecules,
     topology_from_pdb,
 )
 from openff.pablo._pdb_data import PdbData, ResidueMatch
@@ -22,9 +20,8 @@ class TestMatchUnknownMolecules:
         random.shuffle(atom_indices)
         e2_mol.remap({i: j for (i, j) in enumerate(atom_indices)})
 
-        match_mol = _match_unknown_molecules(
-            data=e2_data,
-            indices=tuple(range(e2_mol.n_atoms)),
+        match_mol = e2_data._match_unknown_molecules_to_indices(
+            indices=tuple(sorted(range(e2_mol.n_atoms))),
             unknown_molecules=[e2_mol],
         )
         assert match_mol is not None
@@ -43,9 +40,8 @@ class TestMatchUnknownMolecules:
         e2_mol = Molecule.from_smiles(
             r"C[C@]12CC[C@H]3[C@@H](CCc4cc(O)ccc34)[C@@H]1CC[C@@H]2O",
         )
-        match_mol = _match_unknown_molecules(
-            data=e2_data,
-            indices=tuple(range(e2_mol.n_atoms)),
+        match_mol = e2_data._match_unknown_molecules_to_indices(
+            indices=tuple(sorted(range(e2_mol.n_atoms))),
             unknown_molecules=[e2_mol],
         )
         assert match_mol is not None
@@ -57,7 +53,7 @@ class TestMatchUnknownMolecules:
 
         for i, atom in enumerate(match_mol.atoms):
             assert atom.metadata["residue_name"] == e2_data.res_name[i]
-            assert atom.metadata["residue_number"] == e2_data.res_seq[i]
+            assert str(atom.metadata["residue_number"]) == e2_data.res_seq[i]
             assert atom.metadata["insertion_code"] == e2_data.i_code[i]
             assert atom.metadata["chain_id"] == e2_data.chain_id[i]
             assert atom.metadata["pdb_index"] == i
@@ -78,25 +74,12 @@ class TestMatchUnknownMolecules:
         )
         hoh_mol = Molecule.from_smiles("O")
 
-        match = _match_unknown_molecules(
-            data=e2_data,
-            indices=tuple(range(e2_mol.n_atoms)),
+        match = e2_data._match_unknown_molecules_to_indices(
+            indices=tuple(sorted(range(e2_mol.n_atoms))),
             unknown_molecules=[e2_mol, hoh_mol],
         )
         assert match is not None
         assert match.is_isomorphic_with(e2_mol)
-
-    def test_conect_to_other_residue_raises(
-        self,
-        vicinal_disulfide_data: PdbData,
-    ):
-        cys_mol = Molecule.from_smiles("N[C@H](CS)C(O)=O")
-        with pytest.raises(ValueError):
-            _match_unknown_molecules(
-                data=vicinal_disulfide_data,
-                indices=tuple(range(cys_mol.n_atoms)),
-                unknown_molecules=[cys_mol],
-            )
 
     def test_returns_none_on_failure_to_match(
         self,
@@ -104,9 +87,8 @@ class TestMatchUnknownMolecules:
     ):
         hoh_mol = Molecule.from_smiles("O")
 
-        match = _match_unknown_molecules(
-            data=e2_data,
-            indices=tuple(range(44)),
+        match = e2_data._match_unknown_molecules_to_indices(
+            indices=tuple(sorted(range(44))),
             unknown_molecules=[hoh_mol],
         )
         assert match is None

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -490,15 +490,19 @@ class TestPdbData:
         data = PdbData(name=["H"], element=["h"], charge=[1])
         assert data.subset_matches_residue([0], resdef)
 
-    def test_get_residue_matches_loads_vicinal_disulfide(
+    def test_match_residues_loads_vicinal_disulfide(
         self,
         vicinal_disulfide_data: PdbData,
         cys_def: ResidueDefinition,
         cys_def_deprotonated_sidechain: ResidueDefinition,
     ):
-        match1, match2, *excess_matches = vicinal_disulfide_data.get_residue_matches(
-            residue_database={"CYS": [cys_def, cys_def_deprotonated_sidechain]},
-            additional_substructures=[],
+        match1, match2, *excess_matches = (
+            [p.match for p in residue_matches if isinstance(p.match, (ResidueMatch))]
+            for residue_matches in vicinal_disulfide_data.match_residues(
+                residue_database={"CYS": [cys_def, cys_def_deprotonated_sidechain]},
+                additional_substructures=[],
+                unknown_molecules=[],
+            )
         )
         assert len(excess_matches) == 0
         assert len(match1) == 1

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -220,6 +220,9 @@ def test_process_conects_raises_when_serial_missing():
 
 def test_residue_indices():
     data = PdbData(
+        name=list("ABCDEFGHIJKL"),
+        element=[" "] * 12,
+        charge=[None] * 12,
         res_name=["HOH"] * 2 + ["GLY"] * 10,
         chain_id=["A"] * 4 + ["B"] * 8,
         res_seq=["1"] * 6 + ["2"] * 6,
@@ -241,6 +244,9 @@ def test_residue_indices():
 
 def test_residue_indices_multimodel():
     data = PdbData(
+        name=list("ABCDEFGHIJKL"),
+        element=[" "] * 12,
+        charge=[None] * 12,
         res_name=["HOH"] * 2 + ["GLY"] * 10,
         chain_id=["A"] * 4 + ["B"] * 8,
         res_seq=["1"] * 6 + ["2"] * 6,

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 
 import pytest
+from openff.toolkit import Molecule
 
+from openff.pablo._matching import MoleculeMatch, NoResidueDefinitions, ResidueMismatch
 from openff.pablo._pdb_data import PdbData, ResidueMatch
 from openff.pablo._utils import default_dict
+from openff.pablo.ccd import CCD_RESIDUE_DEFINITION_CACHE
 from openff.pablo.exceptions import UnknownOrAmbiguousSerialInConectError
 from openff.pablo.residue import AtomDefinition, BondDefinition, ResidueDefinition
 
@@ -144,7 +147,7 @@ def test_parse_waters_pdb():
         temp_factor=[0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
         element=["H", "H", "O", "H", "H", "O"],
         charge=[None, None, None, None, None, None],
-        terminated=[False, False, False, True, True, True],
+        terminated=[False, False, False, False, False, True],
         serial_to_index=default_dict(
             list,
             {"1": [0], "2": [1], "3": [2], "4": [3], "5": [4], "6": [5]},
@@ -217,12 +220,13 @@ def test_process_conects_raises_when_serial_missing():
 
 def test_residue_indices():
     data = PdbData(
-        res_name=["HOH"] * 2 + ["GLY"] * 8,
-        chain_id=["A"] * 4 + ["B"] * 6,
-        res_seq=["1"] * 6 + ["2"] * 4,
-        i_code=[" "] * 8 + ["A"] * 2,
-        model=[None] * 10,
-        alt_loc=[""] * 10,
+        res_name=["HOH"] * 2 + ["GLY"] * 10,
+        chain_id=["A"] * 4 + ["B"] * 8,
+        res_seq=["1"] * 6 + ["2"] * 6,
+        i_code=[" "] * 8 + ["A"] * 4,
+        model=[None] * 12,
+        alt_loc=[""] * 12,
+        terminated=[False] * 9 + [True] + [False] * 2,
     )
 
     assert list(data.residue_indices) == [
@@ -231,6 +235,7 @@ def test_residue_indices():
         (4, 5),
         (6, 7),
         (8, 9),
+        (10, 11),
     ]
 
 
@@ -242,6 +247,7 @@ def test_residue_indices_multimodel():
         i_code=[" "] * 8 + ["A"] * 4,
         model=[None] * 10 + [1] * 2,
         alt_loc=[""] * 12,
+        terminated=[False] * 12,
     )
 
     with pytest.warns(match="Multi-model files not supported"):
@@ -423,3 +429,109 @@ def test_match_residues_loads_vicinal_disulfide(
 
     assert match1.residue_definition is cys_def
     assert match2.residue_definition is cys_def
+
+
+def test_get_name_based_matches_one_per_residue(pdbfn: Path):
+    data = PdbData.from_file(pdbfn)
+    results = list(data.get_name_based_matches(CCD_RESIDUE_DEFINITION_CACHE))
+    assert len(results) == len(list(data.residue_indices))
+    assert data.res_idx is not None
+    assert len(list(data.residue_indices)) == len(set(data.res_idx))
+    assert len(data.res_idx) == len(data.serial)
+    assert sorted(set(data.res_idx)) == list(range(data.res_idx[-1] + 1))
+    assert len(results) == len(set(data.res_idx))
+    assert len(results) == data.res_idx[-1] + 1
+
+
+def test_get_name_based_matches_subsequence_contains_noresiduedefs_when_unmatched(
+    he_data: PdbData,
+):
+    results = list(he_data.get_name_based_matches({}))
+    assert len(results) == 1
+    assert len(results[0]) == 1
+    assert isinstance(results[0][0], NoResidueDefinitions)
+
+
+def test_filter_on_polymer_linkages_yields_all_matches_simple(cys_data: PdbData):
+    matches = list(cys_data.get_name_based_matches(CCD_RESIDUE_DEFINITION_CACHE))
+    residue_matches = matches[0]
+    residue_matches.append(
+        MoleculeMatch(
+            index_to_atomdef={i: None for i in residue_matches[0].res_atom_idcs},
+            residue_definition=Molecule.from_smiles("N[C@@H](CS)C(=O)O"),
+        ),
+    )
+    results = list(
+        cys_data.filter_on_polymer_linkages(residue_matches, (), (), [residue_matches]),
+    )
+
+    for before, after in zip(residue_matches, results):
+        if isinstance(before, ResidueMatch):
+            assert isinstance(after, (ResidueMatch, ResidueMismatch))
+        else:
+            assert type(before) is type(after)
+        assert before.residue_definition == after.residue_definition
+
+
+def test_filter_on_polymer_linkages_yields_all_matches():
+    from openff.pablo._tests.utils import get_test_data_path
+    from openff.pablo.chem import PEPTIDE_BOND
+
+    # Loading this PDB file with this augmented CCD cache will test all kinds
+    # of residue-residue interface; see prepared_pdbs/polyglycines.py
+    data = PdbData.from_file(get_test_data_path("prepared_pdbs/polyglycines.pdb"))
+    matches = list(
+        data.get_name_based_matches(
+            CCD_RESIDUE_DEFINITION_CACHE.with_(
+                [
+                    ResidueDefinition.from_smiles(
+                        mapped_smiles="[N-:1]([H:2])[C:3]([H:4])([H:5])[C:6](=[O:7])[O:8][H:9]",
+                        atom_names={
+                            1: "N",
+                            2: "H",
+                            3: "CA",
+                            4: "HA1",
+                            5: "HA2",
+                            6: "C",
+                            7: "O",
+                            8: "OXT",
+                            9: "HXT",
+                        },
+                        residue_name="GLY",
+                        leaving_atoms=(8, 9),
+                        linking_bond=PEPTIDE_BOND,
+                        description="GLYCINE w/ negative formal charge on N",
+                    ),
+                    ResidueDefinition.from_smiles(
+                        mapped_smiles="[N:1]([H:2])([H:8])[C:3]([H:4])([H:5])[C-:6]=[O:7]",
+                        atom_names={
+                            1: "N",
+                            2: "H",
+                            3: "CA",
+                            4: "HA1",
+                            5: "HA2",
+                            6: "C",
+                            7: "O",
+                            8: "H2",
+                        },
+                        residue_name="GLY",
+                        leaving_atoms=(8,),
+                        linking_bond=PEPTIDE_BOND,
+                        description="GLYCINE w/ negative formal charge on C",
+                    ),
+                ],
+            ),
+        ),
+    )
+
+    for residue_matches in matches:
+        results = list(
+            data.filter_on_polymer_linkages(residue_matches, (), (), [residue_matches]),
+        )
+
+        for before, after in zip(residue_matches, results):
+            if isinstance(before, ResidueMatch):
+                assert isinstance(after, (ResidueMatch, ResidueMismatch))
+            else:
+                assert type(before) is type(after)
+            assert before.residue_definition == after.residue_definition

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -374,12 +374,9 @@ class TestPdbData:
         cys_def: ResidueDefinition,
         cys_data: PdbData,
     ):
-        assert (
-            cys_data.subset_matches_residue(
-                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-                cys_def,
-            )
-            is not None
+        assert cys_data.subset_matches_residue(
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+            cys_def,
         )
 
     def test_subset_matches_residue_fails_on_multiply_matched_atom(self):
@@ -396,22 +393,16 @@ class TestPdbData:
         )
         charges: list[int | None] = [None, None]
         elements = ["", ""]
-        assert (
-            PdbData(
-                name=["H1", "H"],
-                charge=charges,
-                element=elements,
-            ).subset_matches_residue([0, 1], res_def)
-            is None
-        )
-        assert (
-            PdbData(
-                name=["O", "H"],
-                charge=charges,
-                element=elements,
-            ).subset_matches_residue([0, 1], res_def)
-            is not None
-        )
+        assert not PdbData(
+            name=["H1", "H"],
+            charge=charges,
+            element=elements,
+        ).subset_matches_residue([0, 1], res_def)
+        assert PdbData(
+            name=["O", "H"],
+            charge=charges,
+            element=elements,
+        ).subset_matches_residue([0, 1], res_def)
 
     def test_subset_matches_residue_succeeds_when_all_leaving_atoms_absent(
         self,
@@ -419,16 +410,9 @@ class TestPdbData:
         cys_data: PdbData,
     ):
         leaving_atoms = {atom.name for atom in cys_def.atoms if atom.leaving}
-        assert (
-            cys_data.subset_matches_residue(
-                [
-                    i
-                    for i, name in enumerate(cys_data.name)
-                    if name not in leaving_atoms
-                ],
-                cys_def,
-            )
-            is not None
+        assert cys_data.subset_matches_residue(
+            [i for i, name in enumerate(cys_data.name) if name not in leaving_atoms],
+            cys_def,
         )
 
     def test_subset_matches_residue_fails_when_nonleaving_atom_missing(
@@ -439,12 +423,9 @@ class TestPdbData:
         # Missing atom 1 (CA), a non-leaving atom
         assert cys_data.name[1] == "CA"
         assert cys_def.name_to_atom["CA"].leaving is False
-        assert (
-            cys_data.subset_matches_residue(
-                [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-                cys_def,
-            )
-            is None
+        assert not cys_data.subset_matches_residue(
+            [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+            cys_def,
         )
 
     def test_subset_matches_residue_fails_when_linkage_leaving_atoms_partially_missing(
@@ -454,12 +435,9 @@ class TestPdbData:
     ):
         # Missing atom 13 (HXT), one of two posterior bond leaving atoms
         assert cys_data.name[13] == "HXT"
-        assert (
-            cys_data.subset_matches_residue(
-                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-                cys_def,
-            )
-            is None
+        assert not cys_data.subset_matches_residue(
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            cys_def,
         )
 
     @pytest.mark.parametrize("bond_name", ("prior_bond", "posterior_bond", "crosslink"))
@@ -475,7 +453,7 @@ class TestPdbData:
             if name not in getattr(cys_def, bond_name + "_leaving_atoms")
         ]
         assert len(subset) in [12, 13]
-        assert cys_data.subset_matches_residue(subset, cys_def) is not None
+        assert cys_data.subset_matches_residue(subset, cys_def)
 
     def test_subset_matches_residue_fails_on_element_mismatch(
         self,
@@ -483,9 +461,7 @@ class TestPdbData:
         cys_data: PdbData,
     ):
         cys_data.element[5] = "Zr"
-        assert (
-            cys_data.subset_matches_residue(range(len(cys_def.atoms)), cys_def) is None
-        )
+        assert not cys_data.subset_matches_residue(range(len(cys_def.atoms)), cys_def)
 
     def test_subset_matches_residue_tolerates_none_charge_and_empty_element(self):
         resdef = ResidueDefinition(
@@ -497,7 +473,7 @@ class TestPdbData:
             residue_name="HPL",
         )
         data = PdbData(name=["H"], element=[""], charge=[None])
-        assert data.subset_matches_residue([0], resdef) is not None
+        assert data.subset_matches_residue([0], resdef)
 
     def test_subset_matches_residue_tolerates_wrong_case_element(self):
         resdef = ResidueDefinition(
@@ -509,7 +485,7 @@ class TestPdbData:
             residue_name="HPL",
         )
         data = PdbData(name=["H"], element=["h"], charge=[1])
-        assert data.subset_matches_residue([0], resdef) is not None
+        assert data.subset_matches_residue([0], resdef)
 
     def test_get_residue_matches_loads_vicinal_disulfide(
         self,

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -497,7 +497,7 @@ class TestPdbData:
         cys_def_deprotonated_sidechain: ResidueDefinition,
     ):
         match1, match2, *excess_matches = (
-            [p.match for p in residue_matches if isinstance(p.match, (ResidueMatch))]
+            [p for p in residue_matches if isinstance(p, ResidueMatch)]
             for residue_matches in vicinal_disulfide_data.match_residues(
                 residue_database={"CYS": [cys_def, cys_def_deprotonated_sidechain]},
                 additional_substructures=[],

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
@@ -9,523 +8,418 @@ from openff.pablo.exceptions import UnknownOrAmbiguousSerialInConectError
 from openff.pablo.residue import AtomDefinition, BondDefinition, ResidueDefinition
 
 
-class TestResidueMatch:
-    def test_get_atom_by_index(self, cys_match: ResidueMatch):
-        for i, atom in enumerate(cys_match.residue_definition.atoms):
-            assert cys_match.atom(i) == atom
-
-    def test_get_atom_by_name(self, cys_match: ResidueMatch):
-        for atom in cys_match.residue_definition.atoms:
-            assert cys_match.atom(atom.name) == atom
-
-    def test_get_atom_type_error(self, cys_match: ResidueMatch):
-        with pytest.raises(TypeError):
-            cys_match.atom(3.14159)  # type: ignore
-
-    def test_set_crosslink_mutates_match(self, cys_match: ResidueMatch):
-        cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["SG"], 99)
-        assert cys_match.crosslink_idcs == (
-            cys_match.canonical_atom_name_to_index["SG"],
-            99,
-        )
-
-    def test_set_crosslink_raises_on_wrong_atom(self, cys_match: ResidueMatch):
-        with pytest.raises(ValueError):
-            cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["C"], 99)
-
-    def test_prototype_index_in_match(self, cys_match: ResidueMatch):
-        assert cys_match.prototype_index in cys_match.index_to_atomdef
-
-    def test_set_crosslink_raises_on_atom1_from_other_residue(
-        self,
-        cys_match: ResidueMatch,
-    ):
-        with pytest.raises(ValueError):
-            n_matched_atoms = len(cys_match.res_atom_idcs)
-            cys_match.set_crosslink(n_matched_atoms + 1, n_matched_atoms + 2)
-
-    def test_set_crosslink_raises_on_atom2_from_this_residue(
-        self,
-        cys_match: ResidueMatch,
-    ):
-        with pytest.raises(ValueError):
-            cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["SG"], 0)
-
-    @pytest.mark.parametrize(
-        "fixture_name, missing_atoms",
+def test_can_load_pdb_file_from_file_name(pdbfn: Path):
+    data = PdbData.from_file(pdbfn)
+    n_atom_records = len(
         [
-            ("cys_match", []),
-            ("cys_match_no_leaving", ["OXT", "HXT", "H2", "HG"]),
-            ("cys_match_no_leaving_deprotonated_sidechain", ["OXT", "HXT", "H2"]),
+            line
+            for line in pdbfn.read_text().splitlines()
+            if line.startswith("ATOM  ") or line.startswith("HETATM")
         ],
     )
-    def test_missing_atoms(
-        self,
-        request: pytest.FixtureRequest,
-        fixture_name: str,
-        missing_atoms: Iterable[str],
-    ):
-        match: ResidueMatch = request.getfixturevalue(fixture_name)
-        assert match.missing_atoms == set(missing_atoms)
+    for field_name in [
+        "name",
+        "model",
+        "serial",
+        "alt_loc",
+        "res_name",
+        "chain_id",
+        "res_seq",
+        "i_code",
+        "x",
+        "y",
+        "z",
+        "occupancy",
+        "temp_factor",
+        "element",
+        "charge",
+        "terminated",
+        "conects",
+    ]:
+        assert len(getattr(data, field_name)) == n_atom_records
 
-    def test_missing_leaving_atoms(
-        self,
-        hoh_def: ResidueDefinition,
-    ):
-        match = ResidueMatch(
-            residue_definition=hoh_def,
-            crosslink_idcs=None,
-            index_to_atomdef={
-                i: atom for i, atom in enumerate(hoh_def.atoms) if atom.name != "O"
-            },
-        )
-        assert match.missing_atoms == {"O"}
-        assert match.missing_leaving_atoms == set()
 
-    @pytest.mark.parametrize(
-        "expect_prop_suffix",
-        ("prior_bond", "posterior_bond", "crosslink"),
+def test_can_load_pdb_file_from_file_oobject(pdbfn: Path):
+    with open(pdbfn) as f:
+        data = PdbData.from_file_object(f)
+    n_atom_records = len(
+        [
+            line
+            for line in pdbfn.read_text().splitlines()
+            if line.startswith("ATOM  ") or line.startswith("HETATM")
+        ],
     )
-    def test_expect_props_false_when_not_supported_by_resdef(
-        self,
-        expect_prop_suffix: str,
-        hoh_match: ResidueMatch,
-    ):
-        assert getattr(hoh_match, "expects_" + expect_prop_suffix) is False
+    for field_name in [
+        "name",
+        "model",
+        "serial",
+        "alt_loc",
+        "res_name",
+        "chain_id",
+        "res_seq",
+        "i_code",
+        "x",
+        "y",
+        "z",
+        "occupancy",
+        "temp_factor",
+        "element",
+        "charge",
+        "terminated",
+        "conects",
+    ]:
+        assert len(getattr(data, field_name)) == n_atom_records
 
-    @pytest.mark.parametrize(
-        "expect_prop_suffix",
-        ("prior_bond", "posterior_bond", "crosslink"),
+
+def test_append_coord_line():
+    data = PdbData()
+    data._append_coord_line(
+        "ATOM     16  HD2 LYS A   1      -1.806   9.969   9.991  1.00  0.00           H",
     )
-    def test_expect_props_false_when_leaving_atoms_present(
-        self,
-        expect_prop_suffix: str,
-        cys_match: ResidueMatch,
-    ):
-        assert getattr(cys_match, "expects_" + expect_prop_suffix) is False
 
-    def test_expect_props_false_when_leaving_atoms_missing_from_resdef(
-        self,
-        cys_match_no_leaving_deprotonated_sidechain: ResidueMatch,
-    ):
-        assert cys_match_no_leaving_deprotonated_sidechain.expects_crosslink is False
-
-    @pytest.mark.parametrize(
-        "expect_prop_suffix",
-        ("prior_bond", "posterior_bond", "crosslink"),
+    assert data == PdbData(
+        line_no=[None],
+        model=[None],
+        serial=["16"],
+        name=["HD2"],
+        alt_loc=[""],
+        res_name=["LYS"],
+        chain_id=["A"],
+        res_seq=["1"],
+        i_code=[" "],
+        x=[-1.806],
+        y=[9.969],
+        z=[9.991],
+        occupancy=[1.00],
+        temp_factor=[0.00],
+        element=["H"],
+        charge=[None],
+        terminated=[False],
+        serial_to_index=default_dict(list, {"16": [0]}),
+        conects=[set()],
+        cryst1_a=None,
+        cryst1_b=None,
+        cryst1_c=None,
+        cryst1_alpha=None,
+        cryst1_beta=None,
+        cryst1_gamma=None,
     )
-    def test_expect_props_true_when_leaving_atoms_absent(
-        self,
-        expect_prop_suffix: str,
-        cys_match_no_leaving: ResidueMatch,
-    ):
-        assert getattr(cys_match_no_leaving, "expects_" + expect_prop_suffix) is True
-
-    def test_match_agrees_with_self(self, any_match: ResidueMatch):
-        any_match.agrees_with(any_match)
 
 
-class TestPdbData:
-    def test_can_load_pdb_file_from_file_name(self, pdbfn: Path):
-        data = PdbData.from_file(pdbfn)
-        n_atom_records = len(
-            [
-                line
-                for line in pdbfn.read_text().splitlines()
-                if line.startswith("ATOM  ") or line.startswith("HETATM")
-            ],
-        )
-        for field_name in [
-            "name",
-            "model",
-            "serial",
-            "alt_loc",
-            "res_name",
-            "chain_id",
-            "res_seq",
-            "i_code",
-            "x",
-            "y",
-            "z",
-            "occupancy",
-            "temp_factor",
-            "element",
-            "charge",
-            "terminated",
-            "conects",
-        ]:
-            assert len(getattr(data, field_name)) == n_atom_records
+def test_parse_waters_pdb():
+    pdblines = [
+        "CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1           1 ",
+        "MODEL        1",
+        "ATOM      1  H1  HOH A   1      -1.806   8.969   4.991  1.00  0.00           H",
+        "ATOM      2  H2  HOH A   1      -2.806   9.969   4.991  0.99  0.00           H",
+        "ATOM      3  O   HOH A   1      -1.806   9.969   4.991  1.00  0.00           O",
+        "HETATM    4  H1  HOH A   2      -1.806   8.969   9.991  1.00  0.00           H",
+        "HETATM    5  H2  HOH A   2      -2.806   9.969   9.991  1.00  0.00           H",
+        "HETATM    6  O   HOH A   2      -1.806   9.969   9.991  1.00  0.00           O",
+        "TER       7      HOH A   2",
+        "CONECT    1    3",
+        "CONECT    2    3",
+        "CONECT    3    1    2",
+        "CONECT    4    6",
+        "CONECT    5    6",
+        "CONECT    6    4    5",
+        "ENDMDL",
+    ]
+    data = PdbData.parse_pdb(pdblines)
 
-    def test_can_load_pdb_file_from_file_oobject(self, pdbfn: Path):
-        with open(pdbfn) as f:
-            data = PdbData.from_file_object(f)
-        n_atom_records = len(
-            [
-                line
-                for line in pdbfn.read_text().splitlines()
-                if line.startswith("ATOM  ") or line.startswith("HETATM")
-            ],
-        )
-        for field_name in [
-            "name",
-            "model",
-            "serial",
-            "alt_loc",
-            "res_name",
-            "chain_id",
-            "res_seq",
-            "i_code",
-            "x",
-            "y",
-            "z",
-            "occupancy",
-            "temp_factor",
-            "element",
-            "charge",
-            "terminated",
-            "conects",
-        ]:
-            assert len(getattr(data, field_name)) == n_atom_records
+    assert data == PdbData(
+        line_no=[3, 4, 5, 6, 7, 8],
+        model=[1, 1, 1, 1, 1, 1],
+        serial=["1", "2", "3", "4", "5", "6"],
+        name=["H1", "H2", "O", "H1", "H2", "O"],
+        alt_loc=["", "", "", "", "", ""],
+        res_name=["HOH", "HOH", "HOH", "HOH", "HOH", "HOH"],
+        chain_id=["A", "A", "A", "A", "A", "A"],
+        res_seq=["1", "1", "1", "2", "2", "2"],
+        i_code=[" ", " ", " ", " ", " ", " "],
+        x=[-1.806, -2.806, -1.806, -1.806, -2.806, -1.806],
+        y=[8.969, 9.969, 9.969, 8.969, 9.969, 9.969],
+        z=[4.991, 4.991, 4.991, 9.991, 9.991, 9.991],
+        occupancy=[1.00, 0.99, 1.00, 1.00, 1.00, 1.00],
+        temp_factor=[0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        element=["H", "H", "O", "H", "H", "O"],
+        charge=[None, None, None, None, None, None],
+        terminated=[False, False, False, True, True, True],
+        serial_to_index=default_dict(
+            list,
+            {"1": [0], "2": [1], "3": [2], "4": [3], "5": [4], "6": [5]},
+        ),
+        conects=[{2}, {2}, {0, 1}, {5}, {5}, {3, 4}],
+        cryst1_a=10.0,
+        cryst1_b=10.0,
+        cryst1_c=10.0,
+        cryst1_alpha=90.0,
+        cryst1_beta=90.0,
+        cryst1_gamma=90.0,
+    )
 
-    def test_append_coord_line(self):
-        data = PdbData()
-        data._append_coord_line(
-            "ATOM     16  HD2 LYS A   1      -1.806   9.969   9.991  1.00  0.00           H",
-        )
 
-        assert data == PdbData(
-            line_no=[None],
-            model=[None],
-            serial=["16"],
-            name=["HD2"],
-            alt_loc=[""],
-            res_name=["LYS"],
-            chain_id=["A"],
-            res_seq=["1"],
-            i_code=[" "],
-            x=[-1.806],
-            y=[9.969],
-            z=[9.991],
-            occupancy=[1.00],
-            temp_factor=[0.00],
-            element=["H"],
-            charge=[None],
-            terminated=[False],
-            serial_to_index=default_dict(list, {"16": [0]}),
-            conects=[set()],
-            cryst1_a=None,
-            cryst1_b=None,
-            cryst1_c=None,
-            cryst1_alpha=None,
-            cryst1_beta=None,
-            cryst1_gamma=None,
-        )
+def test_process_conects_produces_indices():
+    serial_to_index: dict[str, list[int]] = {"3": [0], "4": [1]}
+    lines: list[str] = ["CONECT    3    4"]
 
-    def test_parse_waters_pdb(self):
-        pdblines = [
-            "CRYST1   10.000   10.000   10.000  90.00  90.00  90.00 P 1           1 ",
-            "MODEL        1",
-            "ATOM      1  H1  HOH A   1      -1.806   8.969   4.991  1.00  0.00           H",
-            "ATOM      2  H2  HOH A   1      -2.806   9.969   4.991  0.99  0.00           H",
-            "ATOM      3  O   HOH A   1      -1.806   9.969   4.991  1.00  0.00           O",
-            "HETATM    4  H1  HOH A   2      -1.806   8.969   9.991  1.00  0.00           H",
-            "HETATM    5  H2  HOH A   2      -2.806   9.969   9.991  1.00  0.00           H",
-            "HETATM    6  O   HOH A   2      -1.806   9.969   9.991  1.00  0.00           O",
-            "TER       7      HOH A   2",
-            "CONECT    1    3",
-            "CONECT    2    3",
-            "CONECT    3    1    2",
-            "CONECT    4    6",
-            "CONECT    5    6",
-            "CONECT    6    4    5",
-            "ENDMDL",
-        ]
-        data = PdbData.parse_pdb(pdblines)
+    conects = PdbData._process_conects(
+        lines,
+        serial_to_index,
+        conects=[set(), set()],
+        model=[None, None],
+    )
 
-        assert data == PdbData(
-            line_no=[3, 4, 5, 6, 7, 8],
-            model=[1, 1, 1, 1, 1, 1],
-            serial=["1", "2", "3", "4", "5", "6"],
-            name=["H1", "H2", "O", "H1", "H2", "O"],
-            alt_loc=["", "", "", "", "", ""],
-            res_name=["HOH", "HOH", "HOH", "HOH", "HOH", "HOH"],
-            chain_id=["A", "A", "A", "A", "A", "A"],
-            res_seq=["1", "1", "1", "2", "2", "2"],
-            i_code=[" ", " ", " ", " ", " ", " "],
-            x=[-1.806, -2.806, -1.806, -1.806, -2.806, -1.806],
-            y=[8.969, 9.969, 9.969, 8.969, 9.969, 9.969],
-            z=[4.991, 4.991, 4.991, 9.991, 9.991, 9.991],
-            occupancy=[1.00, 0.99, 1.00, 1.00, 1.00, 1.00],
-            temp_factor=[0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
-            element=["H", "H", "O", "H", "H", "O"],
-            charge=[None, None, None, None, None, None],
-            terminated=[False, False, False, True, True, True],
-            serial_to_index=default_dict(
-                list,
-                {"1": [0], "2": [1], "3": [2], "4": [3], "5": [4], "6": [5]},
-            ),
-            conects=[{2}, {2}, {0, 1}, {5}, {5}, {3, 4}],
-            cryst1_a=10.0,
-            cryst1_b=10.0,
-            cryst1_c=10.0,
-            cryst1_alpha=90.0,
-            cryst1_beta=90.0,
-            cryst1_gamma=90.0,
-        )
+    assert conects == [{1}, {0}]
 
-    def test_process_conects_produces_indices(self):
-        serial_to_index: dict[str, list[int]] = {"3": [0], "4": [1]}
-        lines: list[str] = ["CONECT    3    4"]
 
-        conects = PdbData._process_conects(
+def test_process_conects_works_with_multiple_models():
+    serial_to_index: dict[str, list[int]] = {"3": [0, 2], "4": [1, 3]}
+    model = [1, 1, 2, 2]
+    conects: list[set[int]] = [set(), set(), set(), set()]
+    lines: list[str] = ["CONECT    3    4"]
+
+    conects = PdbData._process_conects(
+        lines,
+        serial_to_index,
+        conects=conects,
+        model=model,
+    )
+
+    assert conects == [{1}, {0}, {3}, {2}]
+
+
+def test_process_conects_raises_when_ambiguous():
+    serial_to_index: dict[str, list[int]] = {"3": [0], "4": [1, 2]}
+    lines: list[str] = ["CONECT    3    4"]
+
+    with pytest.raises(UnknownOrAmbiguousSerialInConectError):
+        PdbData._process_conects(
             lines,
             serial_to_index,
-            conects=[set(), set()],
-            model=[None, None],
+            conects=[set(), set(), set()],
+            model=[None, None, None],
         )
 
-        assert conects == [{1}, {0}]
 
-    def test_process_conects_works_with_multiple_models(self):
-        serial_to_index: dict[str, list[int]] = {"3": [0, 2], "4": [1, 3]}
-        model = [1, 1, 2, 2]
-        conects: list[set[int]] = [set(), set(), set(), set()]
-        lines: list[str] = ["CONECT    3    4"]
+def test_process_conects_raises_when_serial_missing():
+    serial_to_index: dict[str, list[int]] = {"3": [0], "4": [1, 2]}
+    lines: list[str] = ["CONECT    3    5"]
 
-        conects = PdbData._process_conects(
+    with pytest.raises(UnknownOrAmbiguousSerialInConectError):
+        PdbData._process_conects(
             lines,
             serial_to_index,
-            conects=conects,
-            model=model,
+            conects=[set(), set(), set()],
+            model=[None, None, None],
         )
 
-        assert conects == [{1}, {0}, {3}, {2}]
 
-    def test_process_conects_raises_when_ambiguous(self):
-        serial_to_index: dict[str, list[int]] = {"3": [0], "4": [1, 2]}
-        lines: list[str] = ["CONECT    3    4"]
+def test_residue_indices():
+    data = PdbData(
+        res_name=["HOH"] * 2 + ["GLY"] * 8,
+        chain_id=["A"] * 4 + ["B"] * 6,
+        res_seq=["1"] * 6 + ["2"] * 4,
+        i_code=[" "] * 8 + ["A"] * 2,
+        model=[None] * 10,
+        alt_loc=[""] * 10,
+    )
 
-        with pytest.raises(UnknownOrAmbiguousSerialInConectError):
-            PdbData._process_conects(
-                lines,
-                serial_to_index,
-                conects=[set(), set(), set()],
-                model=[None, None, None],
-            )
+    assert list(data.residue_indices) == [
+        (0, 1),
+        (2, 3),
+        (4, 5),
+        (6, 7),
+        (8, 9),
+    ]
 
-    def test_process_conects_raises_when_serial_missing(self):
-        serial_to_index: dict[str, list[int]] = {"3": [0], "4": [1, 2]}
-        lines: list[str] = ["CONECT    3    5"]
 
-        with pytest.raises(UnknownOrAmbiguousSerialInConectError):
-            PdbData._process_conects(
-                lines,
-                serial_to_index,
-                conects=[set(), set(), set()],
-                model=[None, None, None],
-            )
+def test_residue_indices_multimodel():
+    data = PdbData(
+        res_name=["HOH"] * 2 + ["GLY"] * 10,
+        chain_id=["A"] * 4 + ["B"] * 8,
+        res_seq=["1"] * 6 + ["2"] * 6,
+        i_code=[" "] * 8 + ["A"] * 4,
+        model=[None] * 10 + [1] * 2,
+        alt_loc=[""] * 12,
+    )
 
-    def test_residue_indices(self):
-        data = PdbData(
-            res_name=["HOH"] * 2 + ["GLY"] * 8,
-            chain_id=["A"] * 4 + ["B"] * 6,
-            res_seq=["1"] * 6 + ["2"] * 4,
-            i_code=[" "] * 8 + ["A"] * 2,
-            model=[None] * 10,
-            alt_loc=[""] * 10,
+    with pytest.warns(match="Multi-model files not supported"):
+        residues_indices = list(data.residue_indices)
+
+    assert residues_indices == [
+        (0, 1),
+        (2, 3),
+        (4, 5),
+        (6, 7),
+        (8, 9),
+    ]
+
+
+def test_subset_matches_residue_raises_on_empty(
+    hewl_data: PdbData,
+    cys_def: ResidueDefinition,
+):
+    with pytest.raises(ValueError):
+        hewl_data.subset_matches_residue([], cys_def)
+
+
+def test_subset_matches_residue_succeeds_when_all_atoms_present(
+    cys_def: ResidueDefinition,
+    cys_data: PdbData,
+):
+    assert cys_data.subset_matches_residue(
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+        cys_def,
+    )
+
+
+def test_subset_matches_residue_fails_on_multiply_matched_atom():
+    res_def = ResidueDefinition(
+        linking_bond=None,
+        atoms=(
+            AtomDefinition.with_defaults(name="H1", symbol="H", synonyms=["H"]),
+            AtomDefinition.with_defaults(name="O", symbol="O", charge=-1),
+        ),
+        bonds=(BondDefinition.with_defaults(atom1="H1", atom2="O"),),
+        crosslink=None,
+        description="",
+        residue_name="UNK",
+    )
+    charges: list[int | None] = [None, None]
+    elements = ["", ""]
+    assert not PdbData(
+        name=["H1", "H"],
+        charge=charges,
+        element=elements,
+    ).subset_matches_residue([0, 1], res_def)
+    assert PdbData(
+        name=["O", "H"],
+        charge=charges,
+        element=elements,
+    ).subset_matches_residue([0, 1], res_def)
+
+
+def test_subset_matches_residue_succeeds_when_all_leaving_atoms_absent(
+    cys_def: ResidueDefinition,
+    cys_data: PdbData,
+):
+    leaving_atoms = {atom.name for atom in cys_def.atoms if atom.leaving}
+    assert cys_data.subset_matches_residue(
+        [i for i, name in enumerate(cys_data.name) if name not in leaving_atoms],
+        cys_def,
+    )
+
+
+def test_subset_matches_residue_fails_when_nonleaving_atom_missing(
+    cys_def: ResidueDefinition,
+    cys_data: PdbData,
+):
+    # Missing atom 1 (CA), a non-leaving atom
+    assert cys_data.name[1] == "CA"
+    assert cys_def.name_to_atom["CA"].leaving is False
+    assert not cys_data.subset_matches_residue(
+        [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+        cys_def,
+    )
+
+
+def test_subset_matches_residue_fails_when_linkage_leaving_atoms_partially_missing(
+    cys_def: ResidueDefinition,
+    cys_data: PdbData,
+):
+    # Missing atom 13 (HXT), one of two posterior bond leaving atoms
+    assert cys_data.name[13] == "HXT"
+    assert not cys_data.subset_matches_residue(
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        cys_def,
+    )
+
+
+@pytest.mark.parametrize("bond_name", ("prior_bond", "posterior_bond", "crosslink"))
+def test_subset_matches_residue_succeeds_when_posterior_bond_leaving_atoms_missing(
+    cys_def: ResidueDefinition,
+    cys_data: PdbData,
+    bond_name: str,
+):
+    subset = [
+        i
+        for i, name in enumerate(cys_data.name)
+        if name not in getattr(cys_def, bond_name + "_leaving_atoms")
+    ]
+    assert len(subset) in [12, 13]
+    assert cys_data.subset_matches_residue(subset, cys_def)
+
+
+def test_subset_matches_residue_fails_on_element_mismatch(
+    cys_def: ResidueDefinition,
+    cys_data: PdbData,
+):
+    cys_data.element[5] = "Zr"
+    assert not cys_data.subset_matches_residue(range(len(cys_def.atoms)), cys_def)
+
+
+def test_subset_matches_residue_tolerates_none_charge_and_empty_element():
+    resdef = ResidueDefinition(
+        atoms=(AtomDefinition.with_defaults("H", "H", charge=1),),
+        bonds=(),
+        crosslink=None,
+        linking_bond=None,
+        description="",
+        residue_name="HPL",
+    )
+    data = PdbData(name=["H"], element=[""], charge=[None])
+    assert data.subset_matches_residue([0], resdef)
+
+
+def test_subset_matches_residue_tolerates_wrong_case_element():
+    resdef = ResidueDefinition(
+        atoms=(AtomDefinition.with_defaults("H", "H", charge=1),),
+        bonds=(),
+        crosslink=None,
+        linking_bond=None,
+        description="",
+        residue_name="HPL",
+    )
+    data = PdbData(name=["H"], element=["h"], charge=[1])
+    assert data.subset_matches_residue([0], resdef)
+
+
+def test_match_residues_loads_vicinal_disulfide(
+    vicinal_disulfide_data: PdbData,
+    cys_def: ResidueDefinition,
+    cys_def_deprotonated_sidechain: ResidueDefinition,
+):
+    match1, match2, *excess_matches = (
+        [p for p in residue_matches if isinstance(p, ResidueMatch)]
+        for residue_matches in vicinal_disulfide_data.match_residues(
+            residue_database={"CYS": [cys_def, cys_def_deprotonated_sidechain]},
+            additional_substructures=[],
+            unknown_molecules=[],
         )
+    )
+    assert len(excess_matches) == 0
+    assert len(match1) == 1
+    assert len(match2) == 1
+    match1 = match1[0]
+    match2 = match2[0]
 
-        assert list(data.residue_indices) == [
-            (0, 1),
-            (2, 3),
-            (4, 5),
-            (6, 7),
-            (8, 9),
-        ]
+    assert match1.crosslink_idcs is not None and match2.crosslink_idcs is not None
+    sg1, sg2 = match1.crosslink_idcs
+    assert match2.crosslink_idcs == (sg2, sg1)
+    assert vicinal_disulfide_data.name[sg1] == "SG"
+    assert vicinal_disulfide_data.name[sg2] == "SG"
 
-    def test_residue_indices_multimodel(self):
-        data = PdbData(
-            res_name=["HOH"] * 2 + ["GLY"] * 10,
-            chain_id=["A"] * 4 + ["B"] * 8,
-            res_seq=["1"] * 6 + ["2"] * 6,
-            i_code=[" "] * 8 + ["A"] * 4,
-            model=[None] * 10 + [1] * 2,
-            alt_loc=[""] * 12,
-        )
+    assert match1.missing_atoms == {"HXT", "HG", "OXT"}
+    assert match2.missing_atoms == {"H2", "HG"}
 
-        with pytest.warns(match="Multi-model files not supported"):
-            residues_indices = list(data.residue_indices)
+    assert match1.expects_posterior_bond
+    assert not match1.expects_prior_bond
+    assert match1.expects_crosslink
 
-        assert residues_indices == [
-            (0, 1),
-            (2, 3),
-            (4, 5),
-            (6, 7),
-            (8, 9),
-        ]
+    assert not match2.expects_posterior_bond
+    assert match2.expects_prior_bond
+    assert match2.expects_crosslink
 
-    def test_subset_matches_residue_raises_on_empty(
-        self,
-        hewl_data: PdbData,
-        cys_def: ResidueDefinition,
-    ):
-        with pytest.raises(ValueError):
-            hewl_data.subset_matches_residue([], cys_def)
-
-    def test_subset_matches_residue_succeeds_when_all_atoms_present(
-        self,
-        cys_def: ResidueDefinition,
-        cys_data: PdbData,
-    ):
-        assert cys_data.subset_matches_residue(
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-            cys_def,
-        )
-
-    def test_subset_matches_residue_fails_on_multiply_matched_atom(self):
-        res_def = ResidueDefinition(
-            linking_bond=None,
-            atoms=(
-                AtomDefinition.with_defaults(name="H1", symbol="H", synonyms=["H"]),
-                AtomDefinition.with_defaults(name="O", symbol="O", charge=-1),
-            ),
-            bonds=(BondDefinition.with_defaults(atom1="H1", atom2="O"),),
-            crosslink=None,
-            description="",
-            residue_name="UNK",
-        )
-        charges: list[int | None] = [None, None]
-        elements = ["", ""]
-        assert not PdbData(
-            name=["H1", "H"],
-            charge=charges,
-            element=elements,
-        ).subset_matches_residue([0, 1], res_def)
-        assert PdbData(
-            name=["O", "H"],
-            charge=charges,
-            element=elements,
-        ).subset_matches_residue([0, 1], res_def)
-
-    def test_subset_matches_residue_succeeds_when_all_leaving_atoms_absent(
-        self,
-        cys_def: ResidueDefinition,
-        cys_data: PdbData,
-    ):
-        leaving_atoms = {atom.name for atom in cys_def.atoms if atom.leaving}
-        assert cys_data.subset_matches_residue(
-            [i for i, name in enumerate(cys_data.name) if name not in leaving_atoms],
-            cys_def,
-        )
-
-    def test_subset_matches_residue_fails_when_nonleaving_atom_missing(
-        self,
-        cys_def: ResidueDefinition,
-        cys_data: PdbData,
-    ):
-        # Missing atom 1 (CA), a non-leaving atom
-        assert cys_data.name[1] == "CA"
-        assert cys_def.name_to_atom["CA"].leaving is False
-        assert not cys_data.subset_matches_residue(
-            [0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-            cys_def,
-        )
-
-    def test_subset_matches_residue_fails_when_linkage_leaving_atoms_partially_missing(
-        self,
-        cys_def: ResidueDefinition,
-        cys_data: PdbData,
-    ):
-        # Missing atom 13 (HXT), one of two posterior bond leaving atoms
-        assert cys_data.name[13] == "HXT"
-        assert not cys_data.subset_matches_residue(
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-            cys_def,
-        )
-
-    @pytest.mark.parametrize("bond_name", ("prior_bond", "posterior_bond", "crosslink"))
-    def test_subset_matches_residue_succeeds_when_posterior_bond_leaving_atoms_missing(
-        self,
-        cys_def: ResidueDefinition,
-        cys_data: PdbData,
-        bond_name: str,
-    ):
-        subset = [
-            i
-            for i, name in enumerate(cys_data.name)
-            if name not in getattr(cys_def, bond_name + "_leaving_atoms")
-        ]
-        assert len(subset) in [12, 13]
-        assert cys_data.subset_matches_residue(subset, cys_def)
-
-    def test_subset_matches_residue_fails_on_element_mismatch(
-        self,
-        cys_def: ResidueDefinition,
-        cys_data: PdbData,
-    ):
-        cys_data.element[5] = "Zr"
-        assert not cys_data.subset_matches_residue(range(len(cys_def.atoms)), cys_def)
-
-    def test_subset_matches_residue_tolerates_none_charge_and_empty_element(self):
-        resdef = ResidueDefinition(
-            atoms=(AtomDefinition.with_defaults("H", "H", charge=1),),
-            bonds=(),
-            crosslink=None,
-            linking_bond=None,
-            description="",
-            residue_name="HPL",
-        )
-        data = PdbData(name=["H"], element=[""], charge=[None])
-        assert data.subset_matches_residue([0], resdef)
-
-    def test_subset_matches_residue_tolerates_wrong_case_element(self):
-        resdef = ResidueDefinition(
-            atoms=(AtomDefinition.with_defaults("H", "H", charge=1),),
-            bonds=(),
-            crosslink=None,
-            linking_bond=None,
-            description="",
-            residue_name="HPL",
-        )
-        data = PdbData(name=["H"], element=["h"], charge=[1])
-        assert data.subset_matches_residue([0], resdef)
-
-    def test_match_residues_loads_vicinal_disulfide(
-        self,
-        vicinal_disulfide_data: PdbData,
-        cys_def: ResidueDefinition,
-        cys_def_deprotonated_sidechain: ResidueDefinition,
-    ):
-        match1, match2, *excess_matches = (
-            [p for p in residue_matches if isinstance(p, ResidueMatch)]
-            for residue_matches in vicinal_disulfide_data.match_residues(
-                residue_database={"CYS": [cys_def, cys_def_deprotonated_sidechain]},
-                additional_substructures=[],
-                unknown_molecules=[],
-            )
-        )
-        assert len(excess_matches) == 0
-        assert len(match1) == 1
-        assert len(match2) == 1
-        match1 = match1[0]
-        match2 = match2[0]
-
-        assert match1.crosslink_idcs is not None and match2.crosslink_idcs is not None
-        sg1, sg2 = match1.crosslink_idcs
-        assert match2.crosslink_idcs == (sg2, sg1)
-        assert vicinal_disulfide_data.name[sg1] == "SG"
-        assert vicinal_disulfide_data.name[sg2] == "SG"
-
-        assert match1.missing_atoms == {"HXT", "HG", "OXT"}
-        assert match2.missing_atoms == {"H2", "HG"}
-
-        assert match1.expects_posterior_bond
-        assert not match1.expects_prior_bond
-        assert match1.expects_crosslink
-
-        assert not match2.expects_posterior_bond
-        assert match2.expects_prior_bond
-        assert match2.expects_crosslink
-
-        assert match1.residue_definition is cys_def
-        assert match2.residue_definition is cys_def
+    assert match1.residue_definition is cys_def
+    assert match2.residue_definition is cys_def

--- a/openff/pablo/_tests/test_pdb_data.py
+++ b/openff/pablo/_tests/test_pdb_data.py
@@ -24,7 +24,10 @@ class TestResidueMatch:
 
     def test_set_crosslink_mutates_match(self, cys_match: ResidueMatch):
         cys_match.set_crosslink(cys_match.canonical_atom_name_to_index["SG"], 99)
-        assert cys_match.crosslink == (cys_match.canonical_atom_name_to_index["SG"], 99)
+        assert cys_match.crosslink_idcs == (
+            cys_match.canonical_atom_name_to_index["SG"],
+            99,
+        )
 
     def test_set_crosslink_raises_on_wrong_atom(self, cys_match: ResidueMatch):
         with pytest.raises(ValueError):
@@ -71,7 +74,7 @@ class TestResidueMatch:
     ):
         match = ResidueMatch(
             residue_definition=hoh_def,
-            crosslink=None,
+            crosslink_idcs=None,
             index_to_atomdef={
                 i: atom for i, atom in enumerate(hoh_def.atoms) if atom.name != "O"
             },
@@ -88,7 +91,7 @@ class TestResidueMatch:
         expect_prop_suffix: str,
         hoh_match: ResidueMatch,
     ):
-        assert getattr(hoh_match, "expect_" + expect_prop_suffix) is False
+        assert getattr(hoh_match, "expects_" + expect_prop_suffix) is False
 
     @pytest.mark.parametrize(
         "expect_prop_suffix",
@@ -99,13 +102,13 @@ class TestResidueMatch:
         expect_prop_suffix: str,
         cys_match: ResidueMatch,
     ):
-        assert getattr(cys_match, "expect_" + expect_prop_suffix) is False
+        assert getattr(cys_match, "expects_" + expect_prop_suffix) is False
 
     def test_expect_props_false_when_leaving_atoms_missing_from_resdef(
         self,
         cys_match_no_leaving_deprotonated_sidechain: ResidueMatch,
     ):
-        assert cys_match_no_leaving_deprotonated_sidechain.expect_crosslink is False
+        assert cys_match_no_leaving_deprotonated_sidechain.expects_crosslink is False
 
     @pytest.mark.parametrize(
         "expect_prop_suffix",
@@ -116,7 +119,7 @@ class TestResidueMatch:
         expect_prop_suffix: str,
         cys_match_no_leaving: ResidueMatch,
     ):
-        assert getattr(cys_match_no_leaving, "expect_" + expect_prop_suffix) is True
+        assert getattr(cys_match_no_leaving, "expects_" + expect_prop_suffix) is True
 
     def test_match_agrees_with_self(self, any_match: ResidueMatch):
         any_match.agrees_with(any_match)
@@ -503,22 +506,22 @@ class TestPdbData:
         match1 = match1[0]
         match2 = match2[0]
 
-        assert match1.crosslink is not None and match2.crosslink is not None
-        sg1, sg2 = match1.crosslink
-        assert match2.crosslink == (sg2, sg1)
+        assert match1.crosslink_idcs is not None and match2.crosslink_idcs is not None
+        sg1, sg2 = match1.crosslink_idcs
+        assert match2.crosslink_idcs == (sg2, sg1)
         assert vicinal_disulfide_data.name[sg1] == "SG"
         assert vicinal_disulfide_data.name[sg2] == "SG"
 
         assert match1.missing_atoms == {"HXT", "HG", "OXT"}
         assert match2.missing_atoms == {"H2", "HG"}
 
-        assert match1.expect_posterior_bond
-        assert not match1.expect_prior_bond
-        assert match1.expect_crosslink
+        assert match1.expects_posterior_bond
+        assert not match1.expects_prior_bond
+        assert match1.expects_crosslink
 
-        assert not match2.expect_posterior_bond
-        assert match2.expect_prior_bond
-        assert match2.expect_crosslink
+        assert not match2.expects_posterior_bond
+        assert match2.expects_prior_bond
+        assert match2.expects_crosslink
 
         assert match1.residue_definition is cys_def
         assert match2.residue_definition is cys_def

--- a/openff/pablo/_tests/test_pdb_files_against_legacy.py
+++ b/openff/pablo/_tests/test_pdb_files_against_legacy.py
@@ -138,16 +138,17 @@ def connectivity_and_atom_order_and_net_residue_charge_and_metadata_matches_lega
     assert pablo_top.n_molecules == legacy_top.n_molecules
     for pablo_mol, legacy_mol in zip(pablo_top.molecules, legacy_top.molecules):
         assert pablo_mol.n_atoms == legacy_mol.n_atoms
+        assert pablo_mol.hill_formula == legacy_mol.hill_formula
         for pablo_atom, legacy_atom in zip(pablo_mol.atoms, legacy_mol.atoms):
             assert (
                 pablo_atom.name == legacy_atom.name
-                or pablo_atom.metadata["canonical_name"] == legacy_atom.name
+                or pablo_atom.metadata.get("canonical_name", None) == legacy_atom.name
             )
             assert pablo_atom.symbol == legacy_atom.symbol
             # Legacy loader converts "A000" to "10000". New loader is more
-            # hygienic about this, so we need to use `res_seq`, but stringify it
+            # hygienic about this, so it needs to be stringified
             assert (
-                str(pablo_atom.metadata["res_seq"])
+                str(pablo_atom.metadata["residue_number"])
                 == legacy_atom.metadata["residue_number"]
             )
             for key in [

--- a/openff/pablo/_tests/test_pdb_files_against_property.py
+++ b/openff/pablo/_tests/test_pdb_files_against_property.py
@@ -559,7 +559,7 @@ def test_polyglycines_loads_with_augmented_ccd():
     assert topology.molecule(0).is_isomorphic_with(triglycine)
     assert topology.molecule(1).is_isomorphic_with(triglycine)
     assert topology.molecule(2).is_isomorphic_with(triglycine)
-    for i in range(3, 104):
+    for i in range(3, 103):
         molecule = topology.molecule(i)
         assert molecule.n_atoms == 3
         assert molecule.hill_formula == "H2O"

--- a/openff/pablo/_tests/test_pdb_files_against_property.py
+++ b/openff/pablo/_tests/test_pdb_files_against_property.py
@@ -432,10 +432,69 @@ def test_cannot_load_arg_alternate_resonance_form():
     )
 
 
-@pytest.mark.xfail
 def test_misplaced_ter_with_custom_resdef_gives_clear_error():
-    """This needs a clearer error"""
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="failed to match: Posterior bond expected but cannot form polymer bond across TER record",
+    ):
         topology_from_pdb(
             get_test_data_path("capped_ser_extrater.pdb"),
+        )
+
+
+def test_unknown_residue_gives_clear_error():
+    path = get_test_data_path("5ap1_prepared.pdb").absolute()
+
+    def check_err(err: ValueError) -> bool:
+        expected_error = "\n".join(
+            [
+                "some residues could not be identified",
+                "A topology cannot be created without chemical information for every",
+                "atom and bond. The following residues present in the PDB file could",
+                "not be identified from the provided chemical library:",
+                f"  C:UNK#1 ({path}:l4980-5038): No residue definitions",
+            ],
+        )
+
+        assert err.args[0] == expected_error
+        return True
+
+    with pytest.raises(
+        ValueError,
+        check=check_err,
+    ):
+        topology_from_pdb(path)
+
+
+def test_unmatched_residues_give_clear_error(
+    cys_def_deprotonated_sidechain: ResidueDefinition,
+):
+    path = get_test_data_path("3cu9_vicinal_disulfide.pdb").absolute()
+
+    def check_err(err: ValueError) -> bool:
+        expected_error = "\n".join(
+            [
+                "some residues could not be identified",
+                "A topology cannot be created without chemical information for every",
+                "atom and bond. The following residues present in the PDB file could",
+                "not be identified from the provided chemical library:",
+                f"  A:CYS#221 ({path}:l1-11): No matching residue definitions:",
+                "    ╰ CYSTEINE failed to match: found CONECT record that could not be matched with a bond",
+                f"  A:CYS#222 ({path}:l12-23): No matching residue definitions:",
+                "    ╰ CYSTEINE failed to match: found CONECT record that could not be matched with a bond",
+            ],
+        )
+
+        assert err.args[0] == expected_error
+        return err.args[0] == expected_error
+
+    with pytest.raises(
+        ValueError,
+        check=check_err,
+    ):
+        topology_from_pdb(
+            path,
+            residue_database={
+                "CYS": [cys_def_deprotonated_sidechain.replace(crosslink=None)],
+            },
         )

--- a/openff/pablo/_tests/test_pdb_files_against_property.py
+++ b/openff/pablo/_tests/test_pdb_files_against_property.py
@@ -244,7 +244,7 @@ def test_3ip9_loads_with_additional_residue():
                 "residue_number",
                 "insertion_code",
             ]:
-                assert pablo_atom.metadata[key] == legacy_atom.metadata[key]
+                assert str(pablo_atom.metadata[key]) == str(legacy_atom.metadata[key])
 
         pablo_bonds = {
             sort_tuple((bond.atom1_index, bond.atom2_index)) for bond in pablo_mol.bonds

--- a/openff/pablo/_tests/test_pdb_files_against_property.py
+++ b/openff/pablo/_tests/test_pdb_files_against_property.py
@@ -450,9 +450,10 @@ def test_unknown_residue_gives_clear_error():
             [
                 "some residues could not be identified",
                 "A topology cannot be created without chemical information for every",
-                "atom and bond. The following residues present in the PDB file could",
-                "not be identified from the provided chemical library:",
-                f"  C:UNK#1 ({path}:l4980-5038): No residue definitions",
+                "atom and bond. The following residues present in PDB file",
+                str(path),
+                "could not be identified from the provided chemical library:",
+                "  C:UNK#1 (l4980-5038): No residue definitions",
             ],
         )
 
@@ -476,11 +477,13 @@ def test_unmatched_residues_give_clear_error(
             [
                 "some residues could not be identified",
                 "A topology cannot be created without chemical information for every",
-                "atom and bond. The following residues present in the PDB file could",
-                "not be identified from the provided chemical library:",
-                f"  A:CYS#221 ({path}:l1-11): No matching residue definitions:",
+                "atom and bond. The following residues present in PDB file",
+                str(path),
+                "could not be identified from the provided chemical library:",
+                "  A:CYS#221 (l1-11): No matching residue definitions:",
                 "    ╰ CYSTEINE failed to match: found CONECT record that could not be matched with a bond",
-                f"  A:CYS#222 ({path}:l12-23): No matching residue definitions:",
+                "",
+                "  A:CYS#222 (l12-23): No matching residue definitions:",
                 "    ╰ CYSTEINE failed to match: found CONECT record that could not be matched with a bond",
             ],
         )
@@ -498,3 +501,65 @@ def test_unmatched_residues_give_clear_error(
                 "CYS": [cys_def_deprotonated_sidechain.replace(crosslink=None)],
             },
         )
+
+
+def test_polyglycines_loads_with_augmented_ccd():
+    # Loading this PDB file with this augmented CCD cache will test all kinds
+    # of residue-residue interface; see prepared_pdbs/polyglycines.py
+    topology = topology_from_pdb(
+        get_test_data_path("prepared_pdbs/polyglycines.pdb"),
+        residue_database=CCD_RESIDUE_DEFINITION_CACHE.with_(
+            [
+                ResidueDefinition.from_smiles(
+                    mapped_smiles="[N-:1]([H:2])[C:3]([H:4])([H:5])[C:6](=[O:7])[O:8][H:9]",
+                    atom_names={
+                        1: "N",
+                        2: "H",
+                        3: "CA",
+                        4: "HA1",
+                        5: "HA2",
+                        6: "C",
+                        7: "O",
+                        8: "OXT",
+                        9: "HXT",
+                    },
+                    residue_name="GLY",
+                    leaving_atoms=(8, 9),
+                    linking_bond=PEPTIDE_BOND,
+                    description="GLYCINE w/ negative formal charge on N",
+                ),
+                ResidueDefinition.from_smiles(
+                    mapped_smiles="[N:1]([H:2])([H:8])[C:3]([H:4])([H:5])[C-:6]=[O:7]",
+                    atom_names={
+                        1: "N",
+                        2: "H",
+                        3: "CA",
+                        4: "HA1",
+                        5: "HA2",
+                        6: "C",
+                        7: "O",
+                        8: "H2",
+                    },
+                    residue_name="GLY",
+                    leaving_atoms=(8,),
+                    linking_bond=PEPTIDE_BOND,
+                    description="GLYCINE w/ negative formal charge on C",
+                ),
+            ],
+        ),
+    )
+    assert topology.n_molecules == 103
+
+    triglycine = Molecule.from_smiles(
+        "[N-:1]([H:2])[C:3]([H:4])([H:5])[C:6](=[O:7])"
+        + "[N:8]([H:9])[C:10]([H:11])([H:12])[C:13](=[O:14])"
+        + "[N:15]([H:16])[C:17]([H:18])([H:19])[C-:20](=[O:21])",
+    )
+
+    assert topology.molecule(0).is_isomorphic_with(triglycine)
+    assert topology.molecule(1).is_isomorphic_with(triglycine)
+    assert topology.molecule(2).is_isomorphic_with(triglycine)
+    for i in range(3, 104):
+        molecule = topology.molecule(i)
+        assert molecule.n_atoms == 3
+        assert molecule.hill_formula == "H2O"

--- a/openff/pablo/_utils.py
+++ b/openff/pablo/_utils.py
@@ -6,6 +6,7 @@ from typing import (
     Literal,
     ParamSpec,
     TypeAlias,
+    TypeGuard,
     TypeVar,
     TypeVarTuple,
     no_type_check,
@@ -67,6 +68,10 @@ def default_dict(
     dd: DefaultDict[U, T | V] = defaultdict(default_factory)
     dd.update(map)
     return dd
+
+
+def no_none_in_values(d: dict[T, U | None]) -> TypeGuard[dict[T, U]]:
+    return None not in d.values()
 
 
 def unwrap(container: Iterable[T], msg: str = "") -> T:

--- a/openff/pablo/_utils.py
+++ b/openff/pablo/_utils.py
@@ -168,10 +168,10 @@ def dec_hex(s: str) -> int:
     For a string of length n, the string is interpreted as decimal if the value
     is < 10^n. This makes the dec_hex representation identical to a decimal
     integer, except for strings that cannot be parsed as a decimal. For these
-    strings, the first hexadecimal number is interpreted as 10^n, and subsequent
-    numbers continue from there. For example, in PDB files, a fixed width column
-    format, residue numbers for large systems sometimes follow this
-    representation:
+    strings, the first hexadecimal number with a leading digit greater than 9 is
+    interpreted as 10^n, and subsequent numbers continue from there. For
+    example, in PDB files, a fixed width column format, residue numbers for
+    large systems sometimes follow thisrepresentation:
 
         "   1" -> 1
         "   2" -> 2

--- a/openff/pablo/_utils.py
+++ b/openff/pablo/_utils.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import (
@@ -55,7 +56,7 @@ class __UNSET__:
 def dbg(o: T, msg: str = "{}") -> T:
     if "{}" not in msg:
         msg += ": {}"
-    print(msg.format(o))
+    logging.debug(msg.format(o))
     return o
 
 

--- a/openff/pablo/_utils.py
+++ b/openff/pablo/_utils.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import (
+    Any,
     DefaultDict,
     Literal,
     ParamSpec,
@@ -12,6 +13,7 @@ from typing import (
     no_type_check,
     overload,
 )
+from collections.abc import Sequence
 
 import rdkit
 import rdkit.Chem
@@ -165,6 +167,11 @@ def float_or_unknown(s: str) -> float | None:
     if s == "?":
         return None
     return float(s)
+
+
+def is_repeated(n_repeats: int, seq: Sequence[Any]) -> bool:
+    ls = list(seq)
+    return ls == ls[: len(ls) // n_repeats] * n_repeats
 
 
 def dec_hex(s: str) -> int:

--- a/openff/pablo/ccd/_ccdcache.py
+++ b/openff/pablo/ccd/_ccdcache.py
@@ -121,7 +121,6 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
     ):
         self._cache_path = cache_path.resolve()
         self._cache_path.mkdir(parents=True, exist_ok=True)
-
         self._library_paths = {path.resolve() for path in library_paths}
 
         self._definitions: dict[str, list[ResidueDefinition]] = {}
@@ -240,7 +239,7 @@ class CcdCache(Mapping[str, list[ResidueDefinition]]):
             definitions = flatten(map(self._apply_patches, definitions))
 
         stored_definitions = self._definitions.setdefault(res_name, [])
-        stored_definitions.extend(definitions)
+        stored_definitions.extend(set(definitions) - set(stored_definitions))
         return stored_definitions
 
     def _download_cif(self, resname: str) -> str:

--- a/openff/pablo/exceptions.py
+++ b/openff/pablo/exceptions.py
@@ -3,17 +3,13 @@ Exceptions for the PDB loader.
 """
 
 __all__ = [
-    "NoMatchingResidueDefinitionError",
-    "MultipleMatchingResidueDefinitionsError",
+    "PdbResidueMatchError",
     "UnknownOrAmbiguousSerialInConectError",
 ]
 
 
-from collections.abc import Collection, Iterable, Mapping, Sequence
-from itertools import combinations
+from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING
-
-from openff.toolkit import Molecule
 
 from openff.pablo._matching import (
     MoleculeMatch,
@@ -21,11 +17,10 @@ from openff.pablo._matching import (
     ResidueMatch,
     ResidueMismatch,
 )
-from openff.pablo._utils import flatten
+from openff.pablo.residue import ResidueDefinition
 
 if TYPE_CHECKING:
     from openff.pablo._pdb_data import PdbData
-    from openff.pablo.residue import ResidueDefinition
 
 
 def _format_src(data: "PdbData", res_atom_idcs: Sequence[int]) -> str:
@@ -44,9 +39,9 @@ def _format_src(data: "PdbData", res_atom_idcs: Sequence[int]) -> str:
         line_no = f"{first}"
 
     return (
-        f" {data.src_filename}:l{line_no}"
+        f"{data.src_filename}:l{line_no}"
         if data.src_filename is not None
-        else f" l{line_no}"
+        else f"l{line_no}"
     )
 
 
@@ -86,139 +81,42 @@ class PdbResidueMatchError(ValueError):
                 msg.append(f"  {resid} ({src}): No residue definitions")
             else:
                 msg.append(f"  {resid} ({src}): No matching residue definitions:")
-            for err in residue_errors:
+
+            residue_mismatch_resdef_description_lens = [
+                len(match.residue_definition.description)
+                for match in residue_errors
+                if isinstance(match.residue_definition, ResidueDefinition)
+            ]
+            residue_mismatch_resdef_description_max_length = (
+                max(residue_mismatch_resdef_description_lens)
+                if residue_mismatch_resdef_description_lens
+                else 0
+            )
+            for err in sorted(residue_errors, key=lambda x: (type(x), x.sort_key())):
                 if isinstance(err, NoResidueDefinitions):
                     continue
                 elif isinstance(err, ResidueMatch):
                     msg.append(
-                        f"    {err.description}: {err.expects_crosslink=} {err.expects_prior_bond=} {err.expects_posterior_bond=}",
+                        f"    ├ {err.residue_definition.description}: {err.expects_crosslink=} {err.expects_prior_bond=} {err.expects_posterior_bond=}",
                     )
                 elif isinstance(err, MoleculeMatch):
                     msg.append(
-                        f"    Unknown molecule {err.description}",
+                        f"    ├ Unknown molecule {err.description}",
+                    )
+                elif isinstance(err, ResidueMismatch):
+                    desc = err.residue_definition.description
+                    padding = residue_mismatch_resdef_description_max_length - len(desc)
+                    msg.append(
+                        f"    ├{'─' * padding} {desc} "
+                        + f"failed to match: {err.reason}",
                     )
                 else:
-                    msg.append(f"    {err.description}: {err.reasons}")
+                    msg.append(f"    ├ {err.description}")
 
+            if msg[-1].startswith("    ├"):
+                msg[-1] = "    ╰" + msg[-1][5:]
 
-class NoMatchingResidueDefinitionError(ValueError):
-    """Exception raised when a residue is missing from the database"""
-
-    def __init__(
-        self,
-        res_atom_idcs: Sequence[int],
-        data: "PdbData",
-        unknown_molecules: Iterable[Molecule],
-        additional_substructures: Iterable["ResidueDefinition"],
-        residue_database: Mapping[
-            str,
-            Iterable["ResidueDefinition"],
-        ],
-        verbose_errors: bool = False,
-    ):
-        i = res_atom_idcs[0]
-        res_name = data.res_name[i]
-
-        line_nos = sorted(
-            [data.line_no[j] for j in res_atom_idcs],
-            key=lambda x: 0 if x is None else x,
-        )
-        first, last = line_nos[0], line_nos[-1]
-        if (
-            first is not None
-            and last is not None
-            and line_nos == list(range(first, last + 1))
-        ):
-            line_no = f"{first}-{last}"
-        else:
-            line_no = first
-
-        msg = [
-            (
-                "No residue definitions covered all atoms in residue"
-                + f"{data.chain_id[i]}:{res_name}#{data.res_seq[i]}"
-                + (
-                    f" ({data.src_filename}:l{line_no})"
-                    if data.src_filename is not None
-                    else f" (l{line_no})"
-                )
-            ),
-        ]
-        if verbose_errors:
-            residue_definitions = list(residue_database[res_name])
-            if len(residue_definitions) == 0:
-                msg.append("  No residues in database for residue name {res_name}")
-            found_names = {data.name[i] for i in res_atom_idcs}
-            for resdef in residue_definitions:
-                extra_names = found_names.difference(
-                    flatten([atom.name, *atom.synonyms] for atom in resdef.atoms),
-                )
-                missing_names = {
-                    "|".join([atom.name, *atom.synonyms])
-                    for atom in resdef.atoms
-                    if atom.name not in found_names
-                    and all([synonym not in found_names for synonym in atom.synonyms])
-                    and not atom.leaving
-                }
-                missing_leavers = {
-                    "|".join([atom.name, *atom.synonyms])
-                    for atom in resdef.atoms
-                    if atom.name not in found_names
-                    and all([synonym not in found_names for synonym in atom.synonyms])
-                    and atom.leaving
-                }
-                msg.append(f"    In {resdef.description}:")
-                msg.append(f"      {sorted(extra_names)} were found but not expected")
-                msg.append(f"      {sorted(missing_names)} were expected but not found")
-                msg.append(
-                    f"      Leaving atoms {sorted(missing_leavers)} were also not found",
-                )
-
-        super().__init__("\n".join(msg))
-
-
-class MultipleMatchingResidueDefinitionsError(ValueError):
-    def __init__(
-        self,
-        matches: Sequence["ResidueMatch"],
-        res_atom_idcs: tuple[int, ...],
-        data: "PdbData",
-        verbose_errors: bool,
-    ):
-        i = res_atom_idcs[0]
-
-        msg = (
-            f"{len(matches)} residue definitions matched residue "
-            + f"{data.chain_id[i]}:{data.res_name[i]}#{data.res_seq[i]}"
-        )
-
-        if verbose_errors:
-            msg += ":"
-            msg = "\n    ".join(
-                [
-                    msg,
-                    *map(
-                        lambda t: f"{t[0]}: {t[1].residue_definition.description!r} {t[1].expects_crosslink=} {t[1].expects_prior_bond=} {t[1].expects_posterior_bond=}",
-                        enumerate(matches),
-                    ),
-                    *filter(
-                        lambda s: " disagrees with " not in s,
-                        map(
-                            lambda t: f"{t[0]} {'agrees with' if matches[t[0]].agrees_with(matches[t[1]]) else 'disagrees with'} {t[1]}",
-                            combinations(range(len(matches)), 2),
-                        ),
-                    ),
-                    *filter(
-                        lambda s: " != " not in s,
-                        map(
-                            lambda t: f"{t[0]} {'==' if matches[t[0]] == matches[t[1]] else '!='} {t[1]}",
-                            combinations(range(len(matches)), 2),
-                        ),
-                    ),
-                ],
-            )
-
-        super().__init__(msg)
+        return super().__init__("\n".join(msg))
 
 
 class UnknownOrAmbiguousSerialInConectError(ValueError):

--- a/openff/pablo/exceptions.py
+++ b/openff/pablo/exceptions.py
@@ -15,11 +15,90 @@ from typing import TYPE_CHECKING
 
 from openff.toolkit import Molecule
 
+from openff.pablo._matching import (
+    MoleculeMatch,
+    NoResidueDefinitions,
+    ResidueMatch,
+    ResidueMismatch,
+)
 from openff.pablo._utils import flatten
 
 if TYPE_CHECKING:
-    from openff.pablo._pdb_data import PdbData, ResidueMatch
+    from openff.pablo._pdb_data import PdbData
     from openff.pablo.residue import ResidueDefinition
+
+
+def _format_src(data: "PdbData", res_atom_idcs: Sequence[int]) -> str:
+    line_nos = sorted(
+        [data.line_no[j] for j in res_atom_idcs],
+        key=lambda x: 0 if x is None else x,
+    )
+    first, last = line_nos[0], line_nos[-1]
+    if (
+        first is not None
+        and last is not None
+        and line_nos == list(range(first, last + 1))
+    ):
+        line_no = f"{first}-{last}"
+    else:
+        line_no = f"{first}"
+
+    return (
+        f" {data.src_filename}:l{line_no}"
+        if data.src_filename is not None
+        else f" l{line_no}"
+    )
+
+
+class PdbResidueMatchError(ValueError):
+    def __init__(
+        self,
+        data: "PdbData",
+        errors: list[
+            list[ResidueMismatch | NoResidueDefinitions]
+            | list[ResidueMatch | MoleculeMatch]
+        ],
+    ):
+        msg = [
+            "some residues could not be identified",
+            "A topology cannot be created without chemical information for every",
+            "atom and bond. The following residues present in the PDB file could",
+            "not be identified from the provided chemical library:",
+        ]
+
+        for residue_errors in errors:
+            if len(residue_errors) == 0:
+                continue
+
+            prototype_residue_error = residue_errors[0]
+            i = prototype_residue_error.prototype_index
+            src = _format_src(data, prototype_residue_error.res_atom_idcs)
+            resid = f"{data.chain_id[i]}:{data.res_name[i]}#{data.res_seq[i]}"
+
+            if isinstance(prototype_residue_error, ResidueMatch):
+                msg.append(
+                    f"  {resid} ({src}): Multiple conflicting residue definition matches:",
+                )
+            elif (
+                isinstance(prototype_residue_error, NoResidueDefinitions)
+                and len(residue_errors) == 1
+            ):
+                msg.append(f"  {resid} ({src}): No residue definitions")
+            else:
+                msg.append(f"  {resid} ({src}): No matching residue definitions:")
+            for err in residue_errors:
+                if isinstance(err, NoResidueDefinitions):
+                    continue
+                elif isinstance(err, ResidueMatch):
+                    msg.append(
+                        f"    {err.description}: {err.expects_crosslink=} {err.expects_prior_bond=} {err.expects_posterior_bond=}",
+                    )
+                elif isinstance(err, MoleculeMatch):
+                    msg.append(
+                        f"    Unknown molecule {err.description}",
+                    )
+                else:
+                    msg.append(f"    {err.description}: {err.reasons}")
 
 
 class NoMatchingResidueDefinitionError(ValueError):

--- a/openff/pablo/exceptions.py
+++ b/openff/pablo/exceptions.py
@@ -19,14 +19,16 @@ from openff.pablo._matching import (
     ResidueMatch,
     ResidueMismatch,
     SuccessfulMatch,
+    only_matched,
 )
+from openff.pablo._utils import flatten
 from openff.pablo.residue import ResidueDefinition
 
 if TYPE_CHECKING:
     from openff.pablo._pdb_data import PdbData
 
 
-def _format_src(data: "PdbData", res_atom_idcs: Sequence[int]) -> str:
+def _format_linenos(data: "PdbData", res_atom_idcs: Sequence[int]) -> str:
     line_nos = sorted(
         [data.line_no[j] for j in res_atom_idcs],
         key=lambda x: 0 if x is None else x,
@@ -37,15 +39,9 @@ def _format_src(data: "PdbData", res_atom_idcs: Sequence[int]) -> str:
         and last is not None
         and line_nos == list(range(first, last + 1))
     ):
-        line_no = f"{first}-{last}"
+        return f"l{first}-{last}"
     else:
-        line_no = f"{first}"
-
-    return (
-        f"{data.src_filename}:l{line_no}"
-        if data.src_filename is not None
-        else f"l{line_no}"
-    )
+        return f"l{first}"
 
 
 class PdbResidueMatchError(ValueError):
@@ -54,11 +50,15 @@ class PdbResidueMatchError(ValueError):
         data: "PdbData",
         errors: list[list[MismatchProtocol] | list[SuccessfulMatch]],
     ):
-        msg = [
+        msg: list[str] = [
             "some residues could not be identified",
             "A topology cannot be created without chemical information for every",
-            "atom and bond. The following residues present in the PDB file could",
-            "not be identified from the provided chemical library:",
+            (
+                f"atom and bond. The following residues present in PDB file\n{data.src_filename}"
+                if data.src_filename is not None
+                else "atom and bond. The following residues present in the PDB file"
+            ),
+            "could not be identified from the provided chemical library:",
         ]
 
         for residue_errors in errors:
@@ -67,13 +67,49 @@ class PdbResidueMatchError(ValueError):
 
             prototype_residue_error = residue_errors[0]
             i = prototype_residue_error.prototype_index
-            src = _format_src(data, prototype_residue_error.res_atom_idcs)
+            src = _format_linenos(data, prototype_residue_error.res_atom_idcs)
             resid = f"{data.chain_id[i]}:{data.res_name[i]}#{data.res_seq[i]}"
+
+            expects_crosslinks = [
+                err.expects_crosslink for err in only_matched(residue_errors)
+            ]
+            expects_posteriors = [
+                err.expects_posterior_bond for err in only_matched(residue_errors)
+            ]
+            expects_priors = [
+                err.expects_prior_bond for err in only_matched(residue_errors)
+            ]
+
+            residue_mismatch_resdef_description_lens = [
+                len(match.residue_definition.description)
+                for match in residue_errors
+                if isinstance(match.residue_definition, ResidueDefinition)
+            ]
+            max_padding = (
+                max(residue_mismatch_resdef_description_lens)
+                if residue_mismatch_resdef_description_lens
+                else 0
+            )
 
             if isinstance(prototype_residue_error, MatchProtocol):
                 msg.append(
                     f"  {resid} ({src}): Multiple conflicting residue definition matches:",
                 )
+                consensus_expects_start = (
+                    f"    │{' ' * (max_padding - 10)} Every match expects "
+                )
+                if all(expects_crosslinks):
+                    msg.append(consensus_expects_start + "crosslink")
+                elif not any(expects_crosslinks):
+                    msg.append(consensus_expects_start + "no crosslink")
+                if all(expects_priors):
+                    msg.append(consensus_expects_start + "prior bond")
+                elif not any(expects_priors):
+                    msg.append(consensus_expects_start + "no prior bond")
+                if all(expects_posteriors):
+                    msg.append(consensus_expects_start + "posterior bond")
+                elif not any(expects_posteriors):
+                    msg.append(consensus_expects_start + "no posterior bond")
             elif (
                 isinstance(prototype_residue_error, NoResidueDefinitions)
                 and len(residue_errors) == 1
@@ -82,22 +118,37 @@ class PdbResidueMatchError(ValueError):
             else:
                 msg.append(f"  {resid} ({src}): No matching residue definitions:")
 
-            residue_mismatch_resdef_description_lens = [
-                len(match.residue_definition.description)
-                for match in residue_errors
-                if isinstance(match.residue_definition, ResidueDefinition)
-            ]
-            residue_mismatch_resdef_description_max_length = (
-                max(residue_mismatch_resdef_description_lens)
-                if residue_mismatch_resdef_description_lens
-                else 0
-            )
             for err in sorted(residue_errors, key=lambda x: (type(x), x.sort_key())):
                 if isinstance(err, NoResidueDefinitions):
                     continue
                 elif isinstance(err, ResidueMatch):
+                    desc = err.residue_definition.description
+                    padding = max_padding - len(desc)
+                    expects = ", ".join(
+                        flatten(
+                            [
+                                ("crosslink",)
+                                if err.expects_crosslink
+                                and not all(expects_crosslinks)
+                                and any(expects_crosslinks)
+                                else (),
+                                ("posterior bond",)
+                                if err.expects_posterior_bond
+                                and not all(expects_posteriors)
+                                and any(expects_posteriors)
+                                else (),
+                                ("prior bond",)
+                                if err.expects_prior_bond
+                                and not all(expects_priors)
+                                and any(expects_priors)
+                                else (),
+                            ],
+                        ),
+                    )
+                    if expects == "":
+                        expects = "no other linkages"
                     msg.append(
-                        f"    ├ {err.residue_definition.description}: {err.expects_crosslink=} {err.expects_prior_bond=} {err.expects_posterior_bond=}",
+                        f"    ├{'─' * padding} {desc}: expects {expects}",
                     )
                 elif isinstance(err, MoleculeMatch):
                     msg.append(
@@ -105,7 +156,7 @@ class PdbResidueMatchError(ValueError):
                     )
                 elif isinstance(err, ResidueMismatch):
                     desc = err.residue_definition.description
-                    padding = residue_mismatch_resdef_description_max_length - len(desc)
+                    padding = max_padding - len(desc)
                     msg.append(
                         f"    ├{'─' * padding} {desc} "
                         + f"failed to match: {err.reason}",
@@ -115,6 +166,11 @@ class PdbResidueMatchError(ValueError):
 
             if msg[-1].startswith("    ├"):
                 msg[-1] = "    ╰" + msg[-1][5:]
+
+            msg.append("")
+
+        if msg[-1] == "":
+            msg = msg[:-1]
 
         return super().__init__("\n".join(msg))
 

--- a/openff/pablo/exceptions.py
+++ b/openff/pablo/exceptions.py
@@ -10,6 +10,7 @@ __all__ = [
 
 
 from collections.abc import Collection, Iterable, Mapping, Sequence
+from itertools import combinations
 from typing import TYPE_CHECKING
 
 from openff.toolkit import Molecule
@@ -118,9 +119,22 @@ class MultipleMatchingResidueDefinitionsError(ValueError):
                 [
                     msg,
                     *map(
-                        lambda m: m.residue_definition.description
-                        + f" {m.expect_crosslink=} {m.expect_prior_bond=} {m.expect_posterior_bond=}",
-                        matches,
+                        lambda t: f"{t[0]}: {t[1].residue_definition.description!r} {t[1].expects_crosslink=} {t[1].expects_prior_bond=} {t[1].expects_posterior_bond=}",
+                        enumerate(matches),
+                    ),
+                    *filter(
+                        lambda s: " disagrees with " not in s,
+                        map(
+                            lambda t: f"{t[0]} {'agrees with' if matches[t[0]].agrees_with(matches[t[1]]) else 'disagrees with'} {t[1]}",
+                            combinations(range(len(matches)), 2),
+                        ),
+                    ),
+                    *filter(
+                        lambda s: " != " not in s,
+                        map(
+                            lambda t: f"{t[0]} {'==' if matches[t[0]] == matches[t[1]] else '!='} {t[1]}",
+                            combinations(range(len(matches)), 2),
+                        ),
                     ),
                 ],
             )

--- a/openff/pablo/exceptions.py
+++ b/openff/pablo/exceptions.py
@@ -12,6 +12,8 @@ from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING
 
 from openff.pablo._matching import (
+    MatchProtocol,
+    MismatchProtocol,
     MoleculeMatch,
     NoResidueDefinitions,
     ResidueMatch,
@@ -49,10 +51,7 @@ class PdbResidueMatchError(ValueError):
     def __init__(
         self,
         data: "PdbData",
-        errors: list[
-            list[ResidueMismatch | NoResidueDefinitions]
-            | list[ResidueMatch | MoleculeMatch]
-        ],
+        errors: list[list[MismatchProtocol] | list[MatchProtocol]],
     ):
         msg = [
             "some residues could not be identified",
@@ -70,7 +69,7 @@ class PdbResidueMatchError(ValueError):
             src = _format_src(data, prototype_residue_error.res_atom_idcs)
             resid = f"{data.chain_id[i]}:{data.res_name[i]}#{data.res_seq[i]}"
 
-            if isinstance(prototype_residue_error, ResidueMatch):
+            if isinstance(prototype_residue_error, MatchProtocol):
                 msg.append(
                     f"  {resid} ({src}): Multiple conflicting residue definition matches:",
                 )

--- a/openff/pablo/exceptions.py
+++ b/openff/pablo/exceptions.py
@@ -18,6 +18,7 @@ from openff.pablo._matching import (
     NoResidueDefinitions,
     ResidueMatch,
     ResidueMismatch,
+    SuccessfulMatch,
 )
 from openff.pablo.residue import ResidueDefinition
 
@@ -51,7 +52,7 @@ class PdbResidueMatchError(ValueError):
     def __init__(
         self,
         data: "PdbData",
-        errors: list[list[MismatchProtocol] | list[MatchProtocol]],
+        errors: list[list[MismatchProtocol] | list[SuccessfulMatch]],
     ):
         msg = [
             "some residues could not be identified",

--- a/openff/pablo/residue.py
+++ b/openff/pablo/residue.py
@@ -647,18 +647,6 @@ class ResidueDefinition:
 
     def _is_isomorphic_to(self, other: Self) -> bool:
         """Atom and bond ordering insensitive equality test"""
-        if other.linking_bond != self.linking_bond:
-            print(other.linking_bond, "!=", self.linking_bond)
-        if other.crosslink != self.crosslink:
-            print(other.crosslink, "!=", self.crosslink)
-        if set(other.atoms) != set(self.atoms):
-            print(
-                f"{set(other.atoms)-set(self.atoms)=}\n{set(self.atoms)-set(other.atoms)=}",
-            )
-        if set(other.bonds) != set(self.bonds):
-            print(
-                f"{set(other.bonds)-set(self.bonds)=}\n{set(self.bonds)-set(other.bonds)=}",
-            )
         return all(
             [
                 other.linking_bond == self.linking_bond,

--- a/openff/pablo/residue.py
+++ b/openff/pablo/residue.py
@@ -704,6 +704,7 @@ class ResidueDefinition:
                 for atom in self.atoms
                 if atom.name != name
             ],
+            description=self.description + f" -{name}",
         )
 
     def protonated_at(
@@ -757,6 +758,7 @@ class ResidueDefinition:
                     leaving=heavy_atom.leaving,
                 ),
             ],
+            description=self.description + f" +{proton_name}",
         )
 
     def vary_protonation(


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

This is a change that needs some input from other people

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Splits up residues if they are repeats. For example, the following lines fail to match without this change because Pablo sees them as a single residue:
 
```
HETATM   67  O   HOH B   1       2.567  17.568   0.796  1.00  0.00           O  
HETATM   68  H1  HOH B   1       2.065  17.427   1.625  1.00  0.00           H  
HETATM   69  H2  HOH B   1       2.005  17.437   0.001  1.00  0.00           H  
HETATM   71  O   HOH B   1       2.452   0.042   0.001  1.00  0.00           O  
HETATM   72  H1  HOH B   1       1.788   0.003   0.720  1.00  0.00           H  
HETATM   73  H2  HOH B   1       3.368   0.091   0.352  1.00  0.00           H 
```

Depends on #106 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
